### PR TITLE
Don't specify the upload tool versions in platform.txt

### DIFF
--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -112,11 +112,11 @@ recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {
 # AVR Uploader/Programmers tools
 # ------------------------------
 
-tools.avrdude.path={runtime.tools.avrdude-6.3.0-arduino16.path}
+tools.avrdude.path={runtime.tools.avrdude.path}
 tools.avrdude.cmd.path={path}/bin/avrdude
 tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
 
-tools.avrdude.network_cmd={runtime.tools.arduinoOTA-1.3.0.path}/bin/arduinoOTA
+tools.avrdude.network_cmd={runtime.tools.arduinoOTA.path}/bin/arduinoOTA
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q


### PR DESCRIPTION
This change will cause the tool versions specified in the toolsDependencies field of the Boards Manager JSON file to be used with Boards Manager installations. Manual installations will use the newest installed version of the tools. The reason for making this change is it eliminates the need to specify the tool version in two separate locations: platform.txt before the release and package_drazzy.com_index.json after the release, reducing the maintenance burden and the likelihood of ending up with a mismatch.

The reason the tools versions were originally specified in platform.txt is because those lines were copied intact from Arduino megaAVR Boards. I believe the reason Arduino did that is because Arduino Web Editor does not match the Arduino IDE's behavior of determining tool versions by looking at the Boards Manager JSON file, so it ends up using a random tool version if it's not specified in platform.txt.

This pull request lays the groundwork for specifying avrdude 6.3.0-arduino17 as the tool dependency in the next Boards Manager release of megaTinyCore (https://github.com/SpenceKonde/ATTinyCore/issues/339#issuecomment-519290146).