### PR TITLE
Add printf to print class

### DIFF
--- a/megaavr/cores/arduino/api/Print.cpp
+++ b/megaavr/cores/arduino/api/Print.cpp
@@ -197,6 +197,35 @@ size_t Print::println(const Printable& x)
   return n;
 }
 
+// Custom implementation of printf borrowed from the teensy core files
+static int16_t printf_putchar(char c, FILE *fp)
+{
+  ((class Print *)(fdev_get_udata(fp)))->write((uint8_t)c);
+  return 0;
+}
+
+int16_t Print::printf(const char *format, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, format);
+  return vfprintf(&f, format, ap);
+}
+
+int16_t Print::printf(const __FlashStringHelper *format, ...)
+{
+  FILE f;
+  va_list ap;
+
+  fdev_setup_stream(&f, printf_putchar, NULL, _FDEV_SETUP_WRITE);
+  fdev_set_udata(&f, this);
+  va_start(ap, format);
+  return vfprintf_P(&f, (const char *)format, ap);
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base)

--- a/megaavr/cores/arduino/api/Print.h
+++ b/megaavr/cores/arduino/api/Print.h
@@ -77,5 +77,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    int16_t printf(const char *format, ...);
+    int16_t printf(const __FlashStringHelper *format, ...);
 };
 


### PR DESCRIPTION
Printf is not a part of the Print class, and it seems like it's going to stay this way in the official Arduino cores. However, this doesn't mean our cores cannot support it!

Discussion about printf here: https://github.com/arduino/ArduinoCore-API/pull/28