### PR TITLE
Fix max/min PWM value

### DIFF
--- a/megaavr/cores/arduino/timers.h
+++ b/megaavr/cores/arduino/timers.h
@@ -6,7 +6,7 @@
 #define TIME_TRACKING_TIMER_DIVIDER		64		/* Clock divider for TCB3 */
 #define TIME_TRACKING_CYCLES_PER_OVF	(TIME_TRACKING_TICKS_PER_OVF * TIME_TRACKING_TIMER_DIVIDER)
 
-#define PWM_TIMER_PERIOD	0xFF	/* For frequency */
+#define PWM_TIMER_PERIOD	0xFE	/* For frequency */
 #define PWM_TIMER_COMPARE	0x80	/* For duty cycle */
 
 #endif

--- a/megaavr/cores/arduino/wiring_analog.c
+++ b/megaavr/cores/arduino/wiring_analog.c
@@ -133,9 +133,9 @@ void analogWrite(uint8_t pin, int val)
 	switch (digital_pin_timer) { //use only low nybble which defines which timer it is
 
 		case TIMERA0:
-			if(val < 1){	/* if zero or negative drive digital low */
+			if(val <= 0){	/* if zero or negative drive digital low */
 				digitalWrite(pin, LOW);
-			} else if(val > 255){	/* if max or greater drive digital high */
+			} else if(val >= 255){	/* if max or greater drive digital high */
 				digitalWrite(pin, HIGH);
 			} else {
 				/* Calculate correct compare buffer register */


### PR DESCRIPTION
The output of a PWM pin should be completely low when a 0 is passed to the analogWrite function. It should also be completely high when 255 is passed