### PR TITLE
avrdude.conf: fix UPDI flashing

### DIFF
--- a/megaavr/avrdude.conf
+++ b/megaavr/avrdude.conf
@@ -15211,7 +15211,6 @@ part
     id		= ".avr8x";
     desc	= "AVR8X family common values";
     has_updi	= yes;
-    has_pdi	= yes;
     nvm_base	= 0x1000;
     ocd_base	= 0x0F80;
 


### PR DESCRIPTION
Not all AVR8X devices has PDI so "has_pdi"" should not be set at this
level. In the upstream avrdude.conf it is only set for the .xmega parts.

The "has_pdi" takes precedence over "has_updi" in jtag3_initialize() in
jtag3.c in avrdude and even if the programmer is set to be UPDI (flag
PGM_FL_IS_UPDI is set), the PARM3_ARCH is set to PARM3_ARCH_XMEGA
instead of PARM3_ARCH_UPDI and a whole different PARM3_DEVICEDESC is
sent to the device.

On my Attiny416 Xplained Nano with default firmware (avrdude reports
1.13 (rel. 43)), this makes the device signature to be badly read:

avrdude: Device signature = 0x000038 avrdude: Expected signature for
ATtiny416 is 1E 92 21 Double check chip, or use -F to override this
check.

This is related to #96 and #125.