### PR TITLE
twi.h; pack enums

### DIFF
--- a/megaavr/libraries/Wire/src/utility/twi.h
+++ b/megaavr/libraries/Wire/src/utility/twi.h
@@ -33,7 +33,7 @@
 #define TWIS_STATUS_BUSY                 1
 
 /*! Transaction result enumeration. */
-typedef enum TWIM_RESULT_enum {
+typedef enum __attribute__((packed)) TWIM_RESULT_enum {
 	TWIM_RESULT_UNKNOWN          = (0x00<<0),
 	TWIM_RESULT_OK               = (0x01<<0),
 	TWIM_RESULT_BUFFER_OVERFLOW  = (0x02<<0),
@@ -44,7 +44,7 @@ typedef enum TWIM_RESULT_enum {
 } TWIM_RESULT_t;
 
 /* Transaction result enumeration */
-typedef enum TWIS_RESULT_enum {
+typedef enum __attribute__((packed)) TWIS_RESULT_enum {
 	TWIS_RESULT_UNKNOWN            = (0x00<<0),
 	TWIS_RESULT_OK                 = (0x01<<0),
 	TWIS_RESULT_BUFFER_OVERFLOW    = (0x02<<0),
@@ -55,7 +55,7 @@ typedef enum TWIS_RESULT_enum {
 } TWIS_RESULT_t;
 
 /*! TWI Modes */
-typedef enum TWI_MODE_enum {
+typedef enum __attribute__((packed)) TWI_MODE_enum {
 	TWI_MODE_UNKNOWN = 0,
 	TWI_MODE_MASTER = 1,
 	TWI_MODE_SLAVE = 2,


### PR DESCRIPTION
By default enums in C are ints and int on AVR8 is 16-bit making our
enums also 16bits even though they will easily fit in 8-bits. This means
that we need to use more instructions when operating on them which makes
code less compact and less efficient.

This could be globally changed with --short-enums gcc flag but it can be
dangerous if somebody is using some object files with enums compiled
without it. To make change less intrusive, we can change the size of
selected enums with packed attribute.

This reduces the size of an empty sketch with just Wire.h imported from
2926 to 2852 bytes in my case (74 bytes).