### PR TITLE
twi: operate on khz

### DIFF
--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -186,25 +186,26 @@ void TWI_MasterSetBaud(uint32_t frequency){
 //			From 1617 DS: 1000ns @ 100kHz / 300ns @ 400kHz / 120ns @ 1MHz
 
 	uint16_t t_rise;
+	uint16_t freq_khz = frequency/1000;
 	
-	if(frequency < 200000){
-		frequency = 100000;
+	if(freq_khz < 200){
+		freq_khz = 100;
 		t_rise = 1000;
 		
-	} else if (frequency < 800000){
-		frequency = 400000;
+	} else if (freq_khz < 800){
+		freq_khz = 400;
 		t_rise = 300;	
 
-	} else if (frequency < 1200000){
-		frequency = 1000000;
+	} else if (freq_khz < 1200){
+		freq_khz = 1000;
 		t_rise = 120;
 		
 	} else {
-		frequency = 100000;
+		freq_khz = 100;
 		t_rise = 1000;
 	}
 	
-	uint32_t baud = ((F_CPU_CORRECTED/frequency) - (((F_CPU_CORRECTED*t_rise)/1000)/1000)/1000 - 10)/2;
+	uint32_t baud = ((F_CPU_CORRECTED/1000/freq_khz) - (((F_CPU_CORRECTED*t_rise)/1000)/1000)/1000 - 10)/2;
 	TWI0.MBAUD = (uint8_t)baud;
 
 }


### PR DESCRIPTION
Operation on 32-bit values takes a lot of instructions on our 8bit CPUs.
In this case this can be avoided as we know we are only operating on khz
values anyways so we can pre-compute it. The value in khz fits nicely in
16-bit so the generated code will be more compact. As an added bonus I
think it also makes those values easier to read (you don't have to count
those zeros :)).

This reduced size of my sketch from 2926 to 2828 (98 bytes) on my t416.

This is related to #54.