### PR TITLE
TwoWire: avoid vtable by not ineriting HardwareI2C

### DIFF
--- a/megaavr/libraries/Wire/src/Wire.h
+++ b/megaavr/libraries/Wire/src/Wire.h
@@ -32,7 +32,7 @@
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
-class TwoWire : public HardwareI2C
+class TwoWire : public Stream
 {
   private:
     static uint8_t rxBuffer[];


### PR DESCRIPTION
In an attempt to reduce the size or our binaries, we use --gc-sections
linker functionality in hopes not used functions will be automatically
removed by the linker. If, however, you check the symbols in the out ELF
file when Wire.h is included, you can find that all of the methods of
TwoWire class (even those rarely used) were still there.

The linker cannot do that because TwoWire is inheriting from HardwarI2C
class which in turn defines all of the methods as virtual. This means a
vtable is created and it references all of the methods preventing linker
from removing them.

By giving up on this pretty OO concept (which I think is not often used
in Arduino world) we can reduce the size of the binary in many cases.
This change reduces the size of an empty sketch including Wire.h from
2664 bytes to 1478 bytes.

This is related to #54.