### PR TITLE
Updated programmers.txt to support Atmel ICE UPDI

### DIFF
--- a/megaavr/programmers.txt
+++ b/megaavr/programmers.txt
@@ -14,3 +14,9 @@ jtag2updi.program.extra_params=-P{serial.port}
 jtag2updi.program.speed=115200
 jtag2updi.program.use_1200bps_touch=true
 
+atmel_ice_updi.name=Atmel-ICE (UPDI)
+atmel_ice_updi.communication=usb
+atmel_ice_updi.protocol=atmelice_updi
+atmel_ice_updi.program.protocol=atmelice_updi
+atmel_ice_updi.program.tool=avrdude
+atmel_ice_updi.program.extra_params=-Pusb


### PR DESCRIPTION
Added support for the Atmel ICE UPDI programmer.
Be aware that the Atmel ICE might require a firmware update as it needs V1.36!! This can be done with the Atmel studio.

Have tested this and it works. 
This is mainly an easy way to program the explained pro kits with an Atmel ICE programmer.
[Microchip docs](https://microchipdeveloper.com/atmelice:updi)
![afbeelding](https://user-images.githubusercontent.com/21998181/75776701-c3b0c780-5d54-11ea-8aee-e01e761df233.png)
![afbeelding](https://user-images.githubusercontent.com/21998181/75776804-007cbe80-5d55-11ea-82c1-15321dbaed0b.png)

