### PR TITLE
Add Curiosity Nano programmer and avrdude entries

### DIFF
--- a/megaavr/avrdude.conf
+++ b/megaavr/avrdude.conf
@@ -1142,6 +1142,14 @@ programmer
 ;
 
 programmer
+  id    = "curiositynano_updi";
+  desc  = "Microchip CuriosityNano in UPDI mode";
+  type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x2175;
+;
+
+programmer
   id    = "atmelice";
   desc  = "Atmel-ICE (ARM/AVR) in JTAG mode";
   type  = "jtagice3";

--- a/megaavr/programmers.txt
+++ b/megaavr/programmers.txt
@@ -34,3 +34,10 @@ atmel_ice_updi.protocol=atmelice_updi
 atmel_ice_updi.program.protocol=atmelice_updi
 atmel_ice_updi.program.tool=avrdude
 atmel_ice_updi.program.extra_params=-Pusb
+
+curiosity.name=Microchip Curiosity Nano (megaTinyCore)
+curiosity.communication=usb
+curiosity.protocol=curiositynano_updi
+curiosity.program.protocol=curiositynano_updi
+curiosity.program.tool=avrdude
+curiosity.program.extra_params=-Pusb


### PR DESCRIPTION
Add Curiosity Nano to both the programmers.txt file and to the avrdude.conf file, so that these can be used without loading optiboot.

Tested with both a CN ATtiny3217 and a CN Attint1607
