### PR TITLE
Add warning on burning bootloader

### DIFF
--- a/MakeUPDIProgrammer.md
+++ b/MakeUPDIProgrammer.md
@@ -2,7 +2,7 @@
 This is the same method as *pyupdi* uses. A simple TTL serial adapter (such as one of the ubiquitous $1 CH340G serial adapters available on ebay) and a 4.7k resistor are required. Connect the TX and RX pins of the serial adapter with the resistor (many serial adapters already have a 1k resistor in series with the TX pin - if yours does, a 3.3~3.9k resistor would be more appropriate. Connect the RX line to the UPDI pin (the 470 ohm resistor often placed in series with the UPDI pin does not interfere), Vcc to Vcc, and Gnd to Gnd.
 
  _Note: some reports indicate burning the bootloader using this method is not reliable_.
- 
+
 If, for some reason, you do prefer to use jtag2updi, our instructions are below.
 
 ## Step-by-step guide to turn a uno/nano/pro mini into a UPDI programmer

--- a/MakeUPDIProgrammer.md
+++ b/MakeUPDIProgrammer.md
@@ -1,6 +1,8 @@
 # As of 2.2.0, you can program these with a serial adapter and a resistor!
 This is the same method as *pyupdi* uses. A simple TTL serial adapter (such as one of the ubiquitous $1 CH340G serial adapters available on ebay) and a 4.7k resistor are required. Connect the TX and RX pins of the serial adapter with the resistor (many serial adapters already have a 1k resistor in series with the TX pin - if yours does, a 3.3~3.9k resistor would be more appropriate. Connect the RX line to the UPDI pin (the 470 ohm resistor often placed in series with the UPDI pin does not interfere), Vcc to Vcc, and Gnd to Gnd.
 
+ _Note: some reports indicate burning the bootloader using this method is not reliable_.
+ 
 If, for some reason, you do prefer to use jtag2updi, our instructions are below.
 
 ## Step-by-step guide to turn a uno/nano/pro mini into a UPDI programmer

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ If the chip you will be programming has not been bootloaded, connect your UPDI p
 **WARNING: After doing "Burn Bootloader", if you set the UPDI pin to act as reset or IO, the chip cannot be reprogrammed except via the serial bootloader or using an HV UPDI programmer - it is strongly suggested to first burn the bootloader with the UPDI/Reset pin left as UPDI, verify that sketches can be uploaded, and only then "Burn Bootloader" with the UPDI/Reset pin set to act as Reset**
 
  _Note: some reports indicate burning the bootloader using the "Serial port and 4.7k (pyupdi style)" method is not reliable - see the [jtag2updi](MakeUPDIProgrammer.md) method instead_.
- 
+
 After this, connect a serial adapter to the serial pins (as well as ground and Vcc). On the tinyAVR 0/1-series breakout boards which I sell on Tindie, a standard 6-pin "FTDI" header is provided for this that can be connected directly to many serial adapters.
 
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ To use the serial bootloader, select a board definition with (optiboot) after it
 If the chip you will be programming has not been bootloaded, connect your UPDI programmer, and the desired options for clock rate (20/10/5MHz vs 16/8/4/1MHz is all that matters here. The fuses set the base clock to 20MHz or 16MHz, but the prescaler is set at startup by the sketch - so if you "burn bootloader" with 20MHz selected, but upload sketch compiled for 10MHz, that's fine and will work), Brown Out Detect (BOD), Serial port pins for the bootloader, and whether to leave the UPDI pin configured as such, or reconfigure it as a reset pin, and select Tools -> "Burn Bootloader"
 **WARNING: After doing "Burn Bootloader", if you set the UPDI pin to act as reset or IO, the chip cannot be reprogrammed except via the serial bootloader or using an HV UPDI programmer - it is strongly suggested to first burn the bootloader with the UPDI/Reset pin left as UPDI, verify that sketches can be uploaded, and only then "Burn Bootloader" with the UPDI/Reset pin set to act as Reset**
 
+ _Note: some reports indicate burning the bootloader using the "Serial port and 4.7k (pyupdi style)" method is not reliable - see the [jtag2updi](MakeUPDIProgrammer.md) method instead_.
+ 
 After this, connect a serial adapter to the serial pins (as well as ground and Vcc). On the tinyAVR 0/1-series breakout boards which I sell on Tindie, a standard 6-pin "FTDI" header is provided for this that can be connected directly to many serial adapters.
 
 
@@ -522,6 +524,7 @@ Note that, if you have UPDI programming enabled, and desire the convenience of a
 * The new chips have more than one option mapping option for the UART (serial) pins. There is a menu option to choose this, and the one selected when you "burn bootloader" determines which version is used.
 * When you "burn bootloader", the base oscillator frequency is set according to the selected clock speed, but the actual operating speed while running the sketch is set in the uploading code. If you initially set it to 16/8/4/1MHz, you may use any of those options when you upload your sketch and it will run at that speed; if you initially set it to 20/10/5MHz, you may use any of those options. If you wish to change between 16/8/4/1MHz and 20/10/5MHz, you must burn bootloader again - failure to do so will result in it running at the wrong speed, and all timing will be wrong.
 * The "size" of the sketch as reported by avrdude during the upload process is 512b larger (the size of the bootloader) than the actual sketch size when a bootloader is in use (though the size reported at the end of the compile process is the correct size). The fact that the bootloader goes at the start of the flash instead of the end confuses avrdude. The size displayed by the IDE when you "verify" a sketch is correct, the value that avrdude displays is not.
+* Some reports indicate burning the bootloader using the "Serial port and 4.7k (pyupdi style)" method is not reliable - see the [jtag2updi](MakeUPDIProgrammer.md) method instead_.
 
 # Guides
 ## [Power Saving techniques and Sleep](https://github.com/SpenceKonde/megaTinyCore/blob/master/megaavr/extras/PowerSave.md)


### PR DESCRIPTION
The "Serial port and 4.7k (pyupdi style)" method is not reliable as per #320 .

Add language as a warning to other users.