### PR TITLE
Remove unnecessary dependence on micros() for neopixel libs

### DIFF
--- a/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.cpp
+++ b/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.cpp
@@ -856,9 +856,11 @@ void tinyNeoPixel::show(void) {
 
 
   interrupts();
-  #ifndef DISABLEMILLIS
+  #if !defined(DISABLEMILLIS) && !defined(MILLIS_USE_TIMERRTC) && !defined(MILLIS_USE_TIMERRTC_XTAL && !defined(MILLIS_USE_TIMERRTC_XOSC)
     endTime = micros();
     // Save EOD time for latch on next call
+  #else
+    #warning "micros is not available based on timer settings. You must ensure at least 50us between calls to show() or the pixels will never latch"
   #endif
 }
 

--- a/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.h
+++ b/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.h
@@ -296,7 +296,7 @@ class tinyNeoPixel {
   */
   static uint32_t   gamma32(uint32_t x);
 
-  #ifndef DISABLEMILLIS
+  #if !defined(DISABLEMILLIS) && !defined(MILLIS_USE_TIMERRTC) && !defined(MILLIS_USE_TIMERRTC_XTAL) && !defined(MILLIS_USE_TIMERRTC_XOSC)
     inline bool canShow(void) { return (micros() - endTime) >= 50L; }
   #else
     inline bool canShow(void) {return 1;} //we don't have micros here;

--- a/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.cpp
+++ b/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.cpp
@@ -809,15 +809,17 @@ void tinyNeoPixel::show(void) {
       [lo]     "r" (lo));
 
 #else
- #error "CPU SPEED NOT SUPPORTED"
+  #error "CPU SPEED NOT SUPPORTED"
 #endif
 
   // END AVR ----------------------------------------------------------------
 
-
   interrupts();
-  #ifndef DISABLEMILLIS
-  endTime = micros(); // Save EOD time for latch on next call
+  #if !defined(DISABLEMILLIS) && !defined(MILLIS_USE_TIMERRTC) && !defined(MILLIS_USE_TIMERRTC_XTAL) && !defined(MILLIS_USE_TIMERRTC_XOSC))
+    endTime = micros();
+    // Save EOD time for latch on next call
+  #else
+    #warning "micros is not available based on timer settings. You must ensure at least 50us between calls to show() or the pixels will never latch"
   #endif
 }
 

--- a/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.h
+++ b/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.h
@@ -294,14 +294,10 @@ class tinyNeoPixel {
   */
   static uint32_t gamma32(uint32_t x);
 
-  #ifndef DISABLEMILLIS
-    inline bool canShow(void) {
-      return (micros() - endTime) >= 50L;
-    }
+  #if !defined(DISABLEMILLIS) && !defined(MILLIS_USE_TIMERRTC) && !defined(MILLIS_USE_TIMERRTC_XTAL) && !defined(MILLIS_USE_TIMERRTC_XOSC)
+    inline bool canShow(void) { return (micros() - endTime) >= 50L; }
   #else
-    inline bool canShow(void) {
-      return 1; //we don't have micros here;
-    }
+    inline bool canShow(void) {return 1;} //we don't have micros here;
   #endif
 
 


### PR DESCRIPTION
in the cases where we don;t have micros(), we now issue warning, and we now correctly include rtc millis cases, where they were previously not checked for.