### PR TITLE
Update for PORTA ISR

### DIFF
--- a/megaavr/extras/PinInterrupts.md
+++ b/megaavr/extras/PinInterrupts.md
@@ -83,7 +83,7 @@ void loop() {
 
 ISR(PORTA_PORT_vect) {
   byte flags=PORTA.INTFLAGS;
-  PORTA.INTFLAGS=flags; //clear flags
+  PORTA.INTFLAG=0xff // clear all PORTA flags
   if (flags&0x02) {
     interrupt1=1;
   }


### PR DESCRIPTION
PORTA ISR was setting flags equal to INTFLAGS, and then INTFLAGS equal to flags, never setting the bit for the respective pin to 1.

I got started on the series-0 using megaTinyCode, so thank you for the giant boost in my education.