### PR TITLE
Fix path to PACKS

### DIFF
--- a/megaavr/bootloaders/optiboot_x/Makefile
+++ b/megaavr/bootloaders/optiboot_x/Makefile
@@ -85,7 +85,7 @@ endif
 
 # If we have a PACKS directory specified, we should use it...
 ifdef PACKS
-PACK_OPT= -I $(PACKS)/include/ -B $(PACKS)/gcc/dev/$*
+PACK_OPT= -I $(PACKS)/include/ -B $(PACKS)/gcc/dev/$(TARGET)
 ifndef PRODUCTION
 $(info   and Chip-defining PACKS at ${PACKS})
 endif


### PR DESCRIPTION
I had to make the following change in order to be able to use PACKS. I'm not sure if I was doing something wrong but when I used PACKS=path/to/packdir on my build command line, the -B path was messed up used the make target name instead of the device name.