### PR TITLE
Changed TWI baud calculation

### DIFF
--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -64,7 +64,7 @@ void TWI_MasterInit(uint32_t frequency) {
   if (twi_mode != TWI_MODE_UNKNOWN) {
     return;
   }
-#ifdef PORTMUX_TWIROUTEA
+  #ifdef PORTMUX_TWIROUTEA
   if ((PORTMUX.TWIROUTEA & PORTMUX_TWI0_gm) == PORTMUX_TWI0_ALT2_gc) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -72,8 +72,8 @@ void TWI_MasterInit(uint32_t frequency) {
   } else {
     PORTA.OUTCLR = 0x0C; // bits 2 and 3
   }
-#else // megaTinyCore
-#if defined(PORTMUX_TWI0_bm)
+  #else // megaTinyCore
+  #if defined(PORTMUX_TWI0_bm)
   if ((PORTMUX.CTRLB & PORTMUX_TWI0_bm)) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -81,12 +81,12 @@ void TWI_MasterInit(uint32_t frequency) {
   } else {
     PORTB.OUTCLR = 0x03; // else PB0, PB1
   }
-#elif defined(__AVR_ATtinyxy2__)
+  #elif defined(__AVR_ATtinyxy2__)
   PORTA.OUTCLR = 0x06; // 8-pin parts always have it on PA1/2
-#else
+  #else
   PORTB.OUTCLR = 0x03; // else, zero series, no remapping, it's on PB0, PB1
-#endif
-#endif
+  #endif
+  #endif
 
   twi_mode = TWI_MODE_MASTER;
 
@@ -115,7 +115,7 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
     return;
   }
 
-#ifdef PORTMUX_TWIROUTEA
+  #ifdef PORTMUX_TWIROUTEA
   if ((PORTMUX.TWIROUTEA & PORTMUX_TWI0_gm) == PORTMUX_TWI0_ALT2_gc) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -123,8 +123,8 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
   } else {
     PORTA.OUTCLR = 0x0C; // bits 2 and 3
   }
-#else // megaTinyCore
-#if defined(PORTMUX_TWI0_bm)
+  #else // megaTinyCore
+  #if defined(PORTMUX_TWI0_bm)
   if ((PORTMUX.CTRLB & PORTMUX_TWI0_bm)) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -132,12 +132,12 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
   } else {
     PORTB.OUTCLR = 0x03; // else PB0, PB1
   }
-#elif defined(__AVR_ATtinyxy2__)
+  #elif defined(__AVR_ATtinyxy2__)
   PORTA.OUTCLR = 0x06; // 8-pin parts always have it on PA1/2
-#else
+  #else
   PORTB.OUTCLR = 0x03; // else, zero series, no remapping, it's on PB0, PB1
-#endif
-#endif
+  #endif
+  #endif
 
   twi_mode = TWI_MODE_SLAVE;
 
@@ -225,7 +225,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
   uint8_t baud;
 
   // The nonlinearity of the frequency coupled with the processor frequency a general offset has been calculated and tested for different frequency bands
-#if F_CPU > 16000000
+  #if F_CPU > 16000000
   if (frequency <= 100000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 1000;
@@ -243,7 +243,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
     t_rise = 120;
     baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
   }
-#else
+  #else
   if (frequency <= 100000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 1000;
@@ -261,7 +261,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
     t_rise = 120;
     baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
   }
-#endif
+  #endif
 
   TWI0.MBAUD = (uint8_t)baud;
   TWI0.MCTRLA |= TWI_ENABLE_bm;
@@ -356,7 +356,7 @@ uint8_t TWI_MasterWriteRead(uint8_t slave_address,
     master_sendStop = send_stop;
     master_slaveAddress = slave_address << 1;
 
-trigger_action:
+    trigger_action:
 
     /* If write command, send the START condition + Address +
        'R/_W = 0'

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -222,7 +222,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
 
   // Use (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) to calculate the baud rate with t_rise (max) in ns and the frequencies in Hz
   uint16_t t_rise;
-  uint8_t baud;
+  int16_t baud;
 
   // The nonlinearity of the frequency coupled with the processor frequency a general offset has been calculated and tested for different frequency bands
   #if F_CPU > 16000000
@@ -262,6 +262,12 @@ void TWI_MasterSetBaud(uint32_t frequency) {
     baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
   }
   #endif
+
+  if (baud < 1) {
+    baud = 1;
+  } else if (baud > 255) {
+    baud = 255;
+  }
 
   TWI0.MBAUD = (uint8_t)baud;
   TWI0.MCTRLA |= TWI_ENABLE_bm;

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -356,7 +356,7 @@ uint8_t TWI_MasterWriteRead(uint8_t slave_address,
     master_sendStop = send_stop;
     master_slaveAddress = slave_address << 1;
 
-    trigger_action:
+  trigger_action:
 
     /* If write command, send the START condition + Address +
        'R/_W = 0'

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -235,7 +235,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
         t_rise = 300;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-    } else if (frequency <= 800000){    
+    } else if (frequency <= 800000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
         t_rise = 120;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
@@ -253,7 +253,7 @@ void TWI_MasterSetBaud(uint32_t frequency) {
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
         t_rise = 300;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-    } else if (frequency <= 800000){    
+    } else if (frequency <= 800000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
         t_rise = 120;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -220,52 +220,51 @@ uint8_t TWI_MasterReady(void) {
 void TWI_MasterSetBaud(uint32_t frequency) {
   TWI0.MCTRLA &= ~TWI_ENABLE_bm; // The TWI master should be disabled while changing the baud rate
 
+  // Use (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) to calculate the baud rate with t_rise (max) in ns and the frequencies in Hz
+  uint16_t t_rise;
+  uint8_t baud;
 
-    // Use (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) to calculate the baud rate with t_rise (max) in ns and the frequencies in Hz
-    uint16_t t_rise;
-    uint8_t baud;
-
-    // The nonlinearity of the frequency coupled with the processor frequency a general offset has been calculated and tested for different frequency bands
+  // The nonlinearity of the frequency coupled with the processor frequency a general offset has been calculated and tested for different frequency bands
 #if F_CPU > 16000000
-    if(frequency <= 100000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 1000;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 6; // Offset +6
-    } else if (frequency <= 400000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 300;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-    } else if (frequency <= 800000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 120;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
-    } else {
-        TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
-        t_rise = 120;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
-    }
+  if(frequency <= 100000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 1000;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 6; // Offset +6
+  } else if (frequency <= 400000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 300;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
+  } else if (frequency <= 800000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 120;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
+  } else {
+    TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
+    t_rise = 120;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
+  }
 #else
-    if(frequency <= 100000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 1000;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 8; // Offset +8
-    } else if (frequency <= 400000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 300;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-    } else if (frequency <= 800000){
-        TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-        t_rise = 120;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
-    } else {
-        TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
-        t_rise = 120;
-        baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
-    }
+  if(frequency <= 100000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 1000;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 8; // Offset +8
+  } else if (frequency <= 400000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 300;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
+  } else if (frequency <= 800000){
+    TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
+    t_rise = 120;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
+  } else {
+    TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
+    t_rise = 120;
+    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
+  }
 #endif
 
-    TWI0.MBAUD = (uint8_t)baud;
-    TWI0.MCTRLA |= TWI_ENABLE_bm;
+  TWI0.MBAUD = (uint8_t)baud;
+  TWI0.MCTRLA |= TWI_ENABLE_bm;
 }
 
 /*! \brief TWI write transaction.

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -219,8 +219,8 @@ uint8_t TWI_MasterReady(void) {
 */
 void TWI_MasterSetBaud(uint32_t frequency) {
   TWI0.MCTRLA &= ~TWI_ENABLE_bm; // The TWI master should be disabled while changing the baud rate
-    
-    
+
+
     // Use (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) to calculate the baud rate with t_rise (max) in ns and the frequencies in Hz
     uint16_t t_rise;
     uint8_t baud;
@@ -229,11 +229,11 @@ void TWI_MasterSetBaud(uint32_t frequency) {
 #if F_CPU > 16000000
     if(frequency <= 100000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-    t_rise = 1000;
+        t_rise = 1000;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 6; // Offset +6
     } else if (frequency <= 400000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-    t_rise = 300;
+        t_rise = 300;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
     } else if (frequency <= 800000){    
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
@@ -247,11 +247,11 @@ void TWI_MasterSetBaud(uint32_t frequency) {
 #else
     if(frequency <= 100000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-    t_rise = 1000;
+        t_rise = 1000;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 8; // Offset +8
     } else if (frequency <= 400000){
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
-    t_rise = 300;
+        t_rise = 300;
         baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
     } else if (frequency <= 800000){    
         TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus

--- a/megaavr/libraries/Wire/src/utility/twi.c
+++ b/megaavr/libraries/Wire/src/utility/twi.c
@@ -64,7 +64,7 @@ void TWI_MasterInit(uint32_t frequency) {
   if (twi_mode != TWI_MODE_UNKNOWN) {
     return;
   }
-  #ifdef PORTMUX_TWIROUTEA
+#ifdef PORTMUX_TWIROUTEA
   if ((PORTMUX.TWIROUTEA & PORTMUX_TWI0_gm) == PORTMUX_TWI0_ALT2_gc) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -72,8 +72,8 @@ void TWI_MasterInit(uint32_t frequency) {
   } else {
     PORTA.OUTCLR = 0x0C; // bits 2 and 3
   }
-  #else // megaTinyCore
-  #if defined(PORTMUX_TWI0_bm)
+#else // megaTinyCore
+#if defined(PORTMUX_TWI0_bm)
   if ((PORTMUX.CTRLB & PORTMUX_TWI0_bm)) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -81,12 +81,12 @@ void TWI_MasterInit(uint32_t frequency) {
   } else {
     PORTB.OUTCLR = 0x03; // else PB0, PB1
   }
-  #elif defined(__AVR_ATtinyxy2__)
+#elif defined(__AVR_ATtinyxy2__)
   PORTA.OUTCLR = 0x06; // 8-pin parts always have it on PA1/2
-  #else
+#else
   PORTB.OUTCLR = 0x03; // else, zero series, no remapping, it's on PB0, PB1
-  #endif
-  #endif
+#endif
+#endif
 
   twi_mode = TWI_MODE_MASTER;
 
@@ -115,7 +115,7 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
     return;
   }
 
-  #ifdef PORTMUX_TWIROUTEA
+#ifdef PORTMUX_TWIROUTEA
   if ((PORTMUX.TWIROUTEA & PORTMUX_TWI0_gm) == PORTMUX_TWI0_ALT2_gc) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -123,8 +123,8 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
   } else {
     PORTA.OUTCLR = 0x0C; // bits 2 and 3
   }
-  #else // megaTinyCore
-  #if defined(PORTMUX_TWI0_bm)
+#else // megaTinyCore
+#if defined(PORTMUX_TWI0_bm)
   if ((PORTMUX.CTRLB & PORTMUX_TWI0_bm)) {
     // make sure we don't get errata'ed - make sure their bits in the
     // PORTx.OUT registers are 0.
@@ -132,12 +132,12 @@ void TWI_SlaveInit(uint8_t address, uint8_t receive_broadcast, uint8_t second_ad
   } else {
     PORTB.OUTCLR = 0x03; // else PB0, PB1
   }
-  #elif defined(__AVR_ATtinyxy2__)
+#elif defined(__AVR_ATtinyxy2__)
   PORTA.OUTCLR = 0x06; // 8-pin parts always have it on PA1/2
-  #else
+#else
   PORTB.OUTCLR = 0x03; // else, zero series, no remapping, it's on PB0, PB1
-  #endif
-  #endif
+#endif
+#endif
 
   twi_mode = TWI_MODE_SLAVE;
 
@@ -226,40 +226,40 @@ void TWI_MasterSetBaud(uint32_t frequency) {
 
   // The nonlinearity of the frequency coupled with the processor frequency a general offset has been calculated and tested for different frequency bands
 #if F_CPU > 16000000
-  if(frequency <= 100000){
+  if (frequency <= 100000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 1000;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 6; // Offset +6
-  } else if (frequency <= 400000){
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 6; // Offset +6
+  } else if (frequency <= 400000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 300;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-  } else if (frequency <= 800000){
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
+  } else if (frequency <= 800000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 120;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
   } else {
     TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
     t_rise = 120;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
   }
 #else
-  if(frequency <= 100000){
+  if (frequency <= 100000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 1000;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 8; // Offset +8
-  } else if (frequency <= 400000){
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 8; // Offset +8
+  } else if (frequency <= 400000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 300;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
-  } else if (frequency <= 800000){
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) + 1; // Offset +1
+  } else if (frequency <= 800000) {
     TWI0.CTRLA &= ~TWI_FMPEN_bm; // Disable fast mode plus
     t_rise = 120;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000));
   } else {
     TWI0.CTRLA |= TWI_FMPEN_bm; // Enable fast mode plus
     t_rise = 120;
-    baud = (F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
+    baud = (F_CPU / (2 * frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) - 1; // Offset -1
   }
 #endif
 
@@ -356,7 +356,7 @@ uint8_t TWI_MasterWriteRead(uint8_t slave_address,
     master_sendStop = send_stop;
     master_slaveAddress = slave_address << 1;
 
-  trigger_action:
+trigger_action:
 
     /* If write command, send the START condition + Address +
        'R/_W = 0'


### PR DESCRIPTION
Hi @SpenceKonde,

I just saw the latest release notes and saw something regarding the I2C clock (baud rate) and thought I'll post my currently working solution for the attinyxx17 series.
I've been messing around with I2C on the attiny817, attiny1617, and the attiny3217 and I came up with the following calculations.
(F_CPU/(2*frequency)) - (5 + (((F_CPU / 1000000) * t_rise) / 2000)) to calculate the baud rate with t_rise (max) in ns and the frequencies in Hz. This calculation comes from the datasheet for the ATtinyXX17 series. Due to this very generic calculation and the nonlinearity in the frequency transmission I've calculated and tested an extra offset for specific frequency ranges.

I calibrated the internal clock before testing and I've verified the frequencies with a high-end scope. Most frequencies seem to work correctly, however, there is a weird section between 400kHz and 900kHz in which the nonlinearity is not presented well enough in the calculations. I've yet to see devices that work on this frequency range so I think this solution is good enough for now.

I've got an Attiny1627 coming soon on which I can test some of these calculations as well.

If anyone can test this code on a few more devices that would be very helpful. 

Btw I've been working a lot with the XX17 series chips and and got a 1627 coming my way so if you ever need some help with a specific part of an implementation feel free to PM me