### PR TITLE
Changing UART inheritance from HardwareSerial to Stream

### DIFF
--- a/megaavr/cores/megatinycore/HardwareSerial.h
+++ b/megaavr/cores/megatinycore/HardwareSerial.h
@@ -5,5 +5,6 @@
 #ifndef HWSERIALNAME_HACK_H
   #define HWSERIALNAME_HACK_H
   #include <UART.h>
-  #define HardwareSerial UartClass
+  class HardwareSerial : public UartClass {
+  }
 #endif

--- a/megaavr/cores/megatinycore/HardwareSerial.h
+++ b/megaavr/cores/megatinycore/HardwareSerial.h
@@ -5,6 +5,5 @@
 #ifndef HWSERIALNAME_HACK_H
   #define HWSERIALNAME_HACK_H
   #include <UART.h>
-  class HardwareSerial : public UartClass {
-  }
+  #define HardwareSerial UartClass
 #endif

--- a/megaavr/cores/megatinycore/UART.h
+++ b/megaavr/cores/megatinycore/UART.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <inttypes.h>
-#include "api/HardwareSerial.h"
+#include "Stream.h"
 #include "pins_arduino.h"
 #include "UART_constants.h"
 #include "UART_check_pins.h"
@@ -226,7 +226,7 @@ const uint8_t _usart_pins[][4] = {
 /* CHANGING THE MEMBER VARIABLES BETWEEN HERE AND THE OTHER SCARY COMMENT WILL COMPLETELY BREAK SERIAL
  * WHEN USE_ASM_DRE and/or USE_ASM_RXC is used! */
 /* DANGER DANGER DANGER */
-class UartClass : public HardwareSerial {
+class UartClass : public Stream {
   protected:
     volatile USART_t *const _hwserial_module;
     const uint8_t _module_number;

--- a/megaavr/cores/megatinycore/api/Stream.cpp
+++ b/megaavr/cores/megatinycore/api/Stream.cpp
@@ -21,69 +21,66 @@
 
   findMulti/findUntil routines written by Jim Leonard/Xuth
 */
+#include "util/delay.h"
 
 #include "Common.h"
 #include "Stream.h"
 
+
 #define PARSE_TIMEOUT 1000  // default number of milli-seconds to wait
+/*
+__attribute__ ((inline)) void wait_250_clocks() {
+  for (uint8_t i = 0; i < 245; i++) {
+    NOP();
+  }
+}
+*/
 
 int Stream::timedRead() {
-  #if !defined(DISABLEMILLIS)
+  #if !defined(MILLIS_USE_TIMERNONE)
   int c;
-  _startMillis = millis();
+  unsigned long startMillis = millis();
   do {
     c = read();
     if (c >= 0) {
       return c;
     }
-  } while (millis() - _startMillis < _timeout);
+  } while (millis() - startMillis < _timeout);
   return -1;     // -1 indicates timeout
   #else
-  int c; // @FIXME Why are we using an int for this?
-  // We can't use millis() to time ourselves, we will have to
-  // do this another way, timeout is no longer in milliseconds
-  // @TODO cycle-count the contents of this loop and figure out a proper
-  //   number for this, this is currently completely bogus based on
-  //   a complete and utter guess assuming 9.6MHz clock (ATTiny13 commonly)
-  //   This code shamelessly copied from github.com/sleemanj/ATTinyCore
-  uint32_t MaxLoops = _timeout << 10;
-  do {
+  int c; 
+  for (uint32_t i = 0; i < _timeout; i++) {
     c = read();
     if (c >= 0) {
       return c;
     }
-  } while (MaxLoops-- > 0);
+    _delay_us(980); //not 1000, b/c compensation for the rest
+  }
   return -1;     // -1 indicates timeout
   #endif
 }
 
 // private method to peek stream with timeout
 int Stream::timedPeek() {
-  #if !defined(DISABLEMILLIS)
+  #if !defined(MILLIS_USE_TIMERNONE)
   int c;
-  _startMillis = millis();
+  unsigned long startMillis = millis();
   do {
     c = peek();
     if (c >= 0) {
       return c;
     }
-  } while (millis() - _startMillis < _timeout);
+  } while (millis() - startMillis < _timeout);
   return -1;     // -1 indicates timeout
   #else
-  int c; // @FIXME Why are we using an int for this?
-  // We can't use millis() to time ourselves, we will have to
-  // do this another way, timeout is no longer in milliseconds
-  // @TODO cycle-count the contents of this loop and figure out a proper
-  //   number for this, this is currently completely bogus based on
-  //   a complete and utter guess assuming 9.6MHz clock (ATTiny13 commonly)
-  //   This code shamelessly copied from github.com/sleemanj/ATTinyCore
-  uint32_t MaxLoops = _timeout << 10;
-  do {
-    c = peek();
+  int c; 
+  for (uint32_t i = 0; i < _timeout; i++) {
+    c = read();
     if (c >= 0) {
       return c;
     }
-  } while (MaxLoops-- > 0);
+    _delay_us(980); //not 1000, b/c compensation for the rest
+  }
   return -1;     // -1 indicates timeout
   #endif
 }

--- a/megaavr/cores/megatinycore/api/Stream.h
+++ b/megaavr/cores/megatinycore/api/Stream.h
@@ -48,7 +48,7 @@ enum LookaheadMode {
 class Stream : public Print {
   protected:
     unsigned long _timeout;      // number of milliseconds to wait for the next char before aborting timed read
-    unsigned long _startMillis;  // used for timeout measurement
+    unsigned long _startMillis;  // used for timeout measurement, not used, to be deprecated. Not removed because of some assembly
     int timedRead();    // private method to read stream with timeout
     int timedPeek();    // private method to peek stream with timeout
     int peekNextDigit(LookaheadMode lookahead, bool detectDecimal); // returns the next numeric digit in the stream or -1 if timeout


### PR DESCRIPTION
since the Arduino API is using forced to be overwritten virtual function (by making them ` = 0; ` all of the API functions are implemented. by skipping this, only the needed functions should be compiled. Effect: significantly reduces codesize

2. The Stream Class is using a static `_startMillis` variable for timedRead and timedPeak. since I can see no use in it except for some debugging applications without an actual debugger, I suggest to deprecate that and save 4 bytes of RAM in EVERY class that uses stream. Also tried to fix the timedRead and timedPeak for anyon who wants to use it without millis, which is noone, otherwise someone would have complained about the fact that the millis define was renamed....

I was able to reduce the binary size on small programs (that use only read or write) significantly.

Anyway, the problem is, I have no time today to check if it works, and actually, not even a tiny at hand. Will test it on an DA tomorrow. Still opened the PR so you know that it is worked on. 