### PR TITLE
docs: Fix a few typos

### DIFF
--- a/megaavr/bootloaders/optiboot_x/optiboot_x.c
+++ b/megaavr/bootloaders/optiboot_x/optiboot_x.c
@@ -701,7 +701,7 @@ static void do_nvmctrl(uint16_t address, uint8_t command, uint8_t data) {
   /*
   Optiboot is designed to fit in 512 bytes, with a minimum feature set.
   Some chips have a minimum bootloader size of 1024 bytes, and sometimes
-  it is desirable to add extra features even though 512bytes is exceedded.
+  it is desirable to add extra features even though 512bytes is exceeded.
   In that case, the BIGBOOT can be used.
   Our extra features so far don't come close to filling 1k, so we can
   add extra "frivolous" data to the image.   In particular, we can add

--- a/megaavr/cores/megatinycore/Arduino.h
+++ b/megaavr/cores/megatinycore/Arduino.h
@@ -414,7 +414,7 @@ Not enabled. Ugly ways to get delays at very small flash cost.
                     #define CLOCKS_PER_US   (F_CPU / 1000000);    // preprocessed away
                     #define DELAYCLOCKS     (0.8 * CLOCKS_PER_US) // say we wanted a 0.8 us delay.
                     uint8_t x = DELAYCLOCKS / 3;                  // preprocessed into a constant
-                    __asm__ __volatile__ ("dec %0"      "\n\t"    // before this, an ldi is used to load x into the input opperand %0
+                    __asm__ __volatile__ ("dec %0"      "\n\t"    // before this, an ldi is used to load x into the input operand %0
                                           "brne .-4"    "\n\t"
                       #if (DELAYCLOCKS % 3 == 2)                  // 2 clocks extra needed at end
                                           "rjmp .+0"    "\n\t"

--- a/megaavr/cores/megatinycore/new.h
+++ b/megaavr/cores/megatinycore/new.h
@@ -12,7 +12,7 @@
     efficiency.
   Since C++17, there's four more each for new / delete, to support allocation
     of objects with alignment greater than __STDCPP_DEFAULT_NEW_ALIGNMENT__.
-    This has two major differences from the C++14 sized deallocaton.
+    This has two major differences from the C++14 sized deallocation.
     1. It cannot be simply ignored - they presumably wanted alignment for
     a reason; this implementation is not impossible, but nor is it trivial.
     2. If code used on C++14 or earlier is asking for the alignment aware

--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -546,7 +546,7 @@ unsigned long millis() {
           "eor r1,r1"     "\n\t"  // clear out r1
           "sub %A0,r0"    "\n\t"  // Add the sum of terms that fit in a byte to what was ticks in old code.
           "sbc %B0,r1"    "\n"    // carry - see,this is why AVR needs a known zero.
-          : "+r" (ticks));        // Do the rest in C. ticks is a read/write opperand.
+          : "+r" (ticks));        // Do the rest in C. ticks is a read/write operand.
         microseconds = overflows * 1000 + ticks; // nice and clean.
 
       /* The Troublesome Tens - I initially fumbled this after the **now** r1 is 0 line
@@ -613,7 +613,7 @@ unsigned long millis() {
           "eor r1,r1"     "\n\t"  // restore zero_reg
           "add %A0,r0"    "\n\t"  // add to the shifted ticks
           "adc %B0,r1"    "\n"    // carry
-          : "+r" (ticks));        // Do the rest in C. ticks is a read/write opperand.
+          : "+r" (ticks));        // Do the rest in C. ticks is a read/write operand.
         microseconds = overflows * 1000 + ticks;
 /* replaces:
       #elif (F_CPU == 48000000UL) // Extreme overclocking


### PR DESCRIPTION
There are small typos in:
- megaavr/bootloaders/optiboot_x/optiboot_x.c
- megaavr/cores/megatinycore/Arduino.h
- megaavr/cores/megatinycore/new.h
- megaavr/cores/megatinycore/wiring.c

Fixes:
- Should read `operand` rather than `opperand`.
- Should read `exceeded` rather than `exceedded`.
- Should read `deallocation` rather than `deallocaton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md