### PR TITLE
typos in Ref_Analog.md

### DIFF
--- a/megaavr/extras/Ref_Analog.md
+++ b/megaavr/extras/Ref_Analog.md
@@ -120,7 +120,7 @@ This value is used for all analog measurement functions.
 | EA-series   |  apx. 6.4 us |  approx. 5.6 us | Approximately     12 us |              15 | 1 + SAMPDUR           |
 
 
-On the 2-series, we are at least given some numbers: 8pF for the sample and hold cap, and 10k input resistance so a 10k source impedance would give 0.16us time constant, implying that even a 4 ADC clock sampling time is excessive, but at such clock speeds, impedance much above that would need a longer sampling period. You probab
+On the 2-series, we are at least given some numbers: 8pF for the sample and hold cap, and 10k input resistance so a 10k source impedance would give 0.16us time constant, implying that even a 4 ADC clock sampling time is excessive, but at such clock speeds, impedance much above that would need a longer sampling period.
 
 ### analogReadEnh(pin, res=ADC_NATIVE_RESOLUTION, gain=0)
 Enhanced `analogRead()` - Perform a single-ended read on the specified pin. `res` is resolution in bits, which may range from 8 to `ADC_MAX_OVERSAMPLED_RESOLUTION`. This maximum is 13 bits for 0/1-series parts, and 17 for 2-series. If this is less than the native ADC resolution, that resolution is used, and then it is right-shifted 1, 2, or 3 times; if it is more than the native resolution, the accumulation option which will take 4<sup>n</sup> samples (where `n` is `res` native resolution) is selected. Note that maximum sample burst reads are not instantaneous, and in the most extreme cases can take milliseconds. Depending on the nature of the signal - or the realtime demands of your application - the time required for all those samples may limit the resolution that is acceptable. The accumulated result is then decimated (rightshifted n places) to yield a result with the requested resolution, which is returned. See [Atmel app note AVR121](https://ww1.microchip.com/downloads/en/appnotes/doc8003.pdf) - the specific case of the new ADC on the Ex and tinyAVR 2-series is discussed in the newer DS40002200 from Microchip, but it is a rather vapid document). Alternately, to get the raw accumulated ADC readings, pass one of the `ADC_ACC_n` constants for the second argument where `n` is a power of 2 up to 64 (0/1-series), or up to 1024 (2-series). Be aware that the lowest bits of a raw accumulated reading should not be trusted.; they're noise, not data (which is why the decimation step is needed, and why 4x the samples are required for every extra bit of resolution instead of 2x). On 2-series parts *the PGA can be used for single ended measurements*. Valid options for gain on the 2-series are 0 (PGA disabled, default), 1 (unity gain - may be appropriate under some circumstances, though I don't know what those are), or powers of 2 up to 16 (for 2x to 16x gain). On AVR Dx and tinyAVR 0/1-series parts, the gain argument should be omitted or 0; these do not have a PGA.
@@ -177,7 +177,7 @@ analogClockSpeed(300);                  // set to 300 kHz
 Serial.println(analogClockSpeed());     // prints a number near 300 - the closest to 300 that was possible without going over.
 
 // ****** For 0/1-series *******
-Serial.println(analogClockSpeed(3000)); // sets prescaler such that frequency of ADC clock is as
+Serial.println(analogClockSpeed(2000)); // sets prescaler such that frequency of ADC clock is as
 // close to but not more than 2000 (kHz) which is the maximum supported according to the datasheet.
 // Any number of 2000 or higher will get same results.
 Serial.println(analogClockSpeed(20));   // A ridiculously slow ADC clock request.


### PR DESCRIPTION
Fix two typos.  One of them was in incomplete thought that I didn't know how to complete so I removed it: "You probab"<eol>. If you remember the thought...

The other might have been intended as a demonstration that numbers over the spec are treated as the spec but the choice of 3000 with the comment then using 2000 multiple times seemed more like a typo. If it was intended to be illustrative, perhaps:

Serial.println(analogClockSpeed(2345)); // sets prescaler such that frequency of ADC clock is as
// close to but not more than min(2000, 2345) (kHz) where 2000 is the maximum supported according to the datasheet.
// Any number of 2000 or higher will get same results.

