### PR TITLE
fix incorrect clock prescalers for 4mhz and 2mhz - new version, does not touch boards.txt

### DIFF
--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -1341,7 +1341,7 @@ void __attribute__((weak)) init_clock() {
       #elif (F_CPU == 4000000) // 16MHz prescaled by 4
         /* Clock DIV4 */
         _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_4X_gc));
-      #elif (F_CPU == 2000000) // 16MHz prescaled by 16
+      #elif (F_CPU == 2000000) // 16MHz prescaled by 8
         /* Clock DIV8 */
         _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_8X_gc));
       #elif (F_CPU == 1000000) // 16MHz prescaled by 16

--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -1340,10 +1340,10 @@ void __attribute__((weak)) init_clock() {
         _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_4X_gc));
       #elif (F_CPU == 4000000) // 16MHz prescaled by 4
         /* Clock DIV4 */
-        _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_8X_gc));
+        _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_4X_gc));
       #elif (F_CPU == 2000000) // 16MHz prescaled by 16
-        /* Clock DIV16 */
-        _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_16X_gc));
+        /* Clock DIV8 */
+        _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_8X_gc));
       #elif (F_CPU == 1000000) // 16MHz prescaled by 16
         /* Clock DIV16 */
         _PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, (CLKCTRL_PEN_bm | CLKCTRL_PDIV_16X_gc));


### PR DESCRIPTION
this is a clean diff to just fix wiring.c prescalers had comments and code that didn't agree and the 2mhz was still 1mhz. 