### PR TITLE
automate version expansion

### DIFF
--- a/megaavr/extras/development/expand_platform_txt.py
+++ b/megaavr/extras/development/expand_platform_txt.py
@@ -1,0 +1,32 @@
+# expands platform.txt.in to produce platform.txt on stdout
+# stores values defined by versionnum.x=y
+# replaces the line version={versionnum.x}...{versionnum.y}... with the values above
+
+import re, sys
+
+vars = {}
+with open("platform.txt.in") as f:
+    for l in f:
+        l = l.strip()
+        m = re.match("[ ]*versionnum.([a-z]*)[ ]*=[ ]*(.*)[ ]*", l)
+        if m:
+            if m.group(1) in vars:
+                print("duplicate definition of:", m.group(1), file=sys.stderr)
+                exit(1)
+            else:
+                vars[m.group(1)] = m.group(2)
+        m = re.match("([ ]*version=)(.*)", l)
+        if m:  # not elseif, want the first case to fall through
+            exp = m.group(1) + m.group(2)
+            for k in vars:
+                exp = exp.replace("{versionnum." + k + "}", vars[k])
+            if exp.find("{") >= 0 or exp.find("}") >= 0:
+                print(
+                    '"' + exp + '"',
+                    "still contains { or }, define the value above",
+                    file=sys.stderr,
+                )
+                exit(1)
+            print(exp)
+        else:  # not the line being changed
+            print(l)

--- a/megaavr/platform.txt.in
+++ b/megaavr/platform.txt.in
@@ -11,7 +11,7 @@ versionnum.patch=0
 versionnum.postfix=
 versionnum.released=0
 
-version=2.6.0
+version={versionnum.major}.{versionnum.minor}.{versionnum.patch}{versionnum.postfix}
 
 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DMEGATINYCORE="{version}" -DMEGATINYCORE_MAJOR={versionnum.major}UL -DMEGATINYCORE_MINOR={versionnum.minor}UL -DMEGATINYCORE_PATCH={versionnum.patch}UL -DMEGATINYCORE_RELEASED={versionnum.released}
 


### PR DESCRIPTION
script to generate platform.txt from platform.txt.in
platform.txt renamed to platform.txt.in
output of script checked in so change doesn't break automated tests
left it general so any variable versionnum.* will get expanded to whatever was after the =

to run:
python3 extras/development/expand_platform_txt.py > platform.txt

result:
```patch
--- platform.txt.in	2022-08-18 15:45:49.000000000 -0700
+++ platform.txt	2022-08-18 16:07:54.000000000 -0700
@@ -11,7 +11,7 @@
 versionnum.postfix=
 versionnum.released=0

-version={versionnum.major}.{versionnum.minor}.{versionnum.patch}{versionnum.postfix}
+version=2.6.0

 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DMEGATINYCORE="{version}" -DMEGATINYCORE_MAJOR={versionnum.major}UL -DMEGATINYCORE_MINOR={versionnum.minor}UL -DMEGATINYCORE_PATCH={versionnum.patch}UL -DMEGATINYCORE_RELEASED={versionnum.released}
```