### PR TITLE
Ignore RTC CMP interrupt in millis()

### DIFF
--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -171,7 +171,13 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
       timer_millis += 2;
     #endif
   #else
-    #if !defined(MILLIS_USE_TIMERRTC) // TCA0 or TCD0
+    #if defined(MILLIS_USE_TIMERRTC)
+      // if RTC is used as timer, we only increment the overflow count
+      // Overflow count isn't used for TCB's
+      if (RTC.INTFLAGS & RTC_OVF_bm) {
+        timer_overflow_count++;
+      }
+    #else // TCA0 or TCD0
       uint32_t m = timer_millis;
       uint16_t f = timer_fract;
       m += MILLIS_INC;
@@ -183,10 +189,8 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
       }
       timer_fract = f;
       timer_millis = m;
+      timer_overflow_count++;
     #endif
-    // if RTC is used as timer, we only increment the overflow count
-    // Overflow count isn't used for TCB's
-    timer_overflow_count++;
   #endif
   /* Clear flag */
   #if defined(MILLIS_USE_TIMERA0)
@@ -194,7 +198,7 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
   #elif defined(MILLIS_USE_TIMERD0)
     TCD0.INTFLAGS = TCD_OVF_bm;
   #elif defined(MILLIS_USE_TIMERRTC)
-    RTC.INTFLAGS = RTC_OVF_bm;
+    RTC.INTFLAGS = RTC_OVF_bm | RTC_CMP_bm;
   #else // timerb
     _timer->INTFLAGS = TCB_CAPT_bm;
   #endif


### PR DESCRIPTION
By ignoring CMP interrupts and only incrementing timer_overflow_count on OVF interrupts, user code may use the CMP interrupt to wake the microcontroller even when using MILLIS_USE_TIMERRTC

---------

With this PR, user code can trivially set `RTC.CMP` to wake up from sleep while still tracking `millis()` using the RTC. Example code below:

```cpp
void setup() {
    // use standby sleep (not power down) since we need the RTC
    set_sleep_mode(SLEEP_MODE_STANDBY);
    sleep_enable();
    RTC.INTCTRL &= ~0x2; // disable CMP interrupt (for good measure)
    RTC.INTFLAGS = RTC_CMP_bm; // clear CMP interrupt (INTFLAGS == 2 at poweron???)
}

void loop() {
    ...
}

void sleep(uint32_t forMillis) {
    uint32_t startMillis = millis();
    uint32_t endMillis = startMillis + forMillis;

    for (uint32_t currentMillis = millis();
            (currentMillis - startMillis) < forMillis;
            currentMillis = millis()) {
        sleepForUpToMillis(endMillis - currentMillis);
    }
}

void sleepForUpToMillis(uint32_t targetMillis) {
    if (targetMillis <= 2) {
        // avoid inadvertantly sleeping for a very long time if there is a delay longer
        // than targetMillis between setting RTC.CMP and calling sleep_cpu() for very
        // short targetMillis (we'll assume no delay will last more than 2ms, set higher
        // if there are very slow ISRs)
        return;
    }

    uint16_t ticks;

    if (targetMillis >= 64000) {
        // limit sleep to less than rtc period
        ticks = 65535;
    } else {
        // each tick is 1000*32/2^15 ms, simplified 1000/1024 ms
        ticks = targetMillis * 1.024; // div 1000 mul 1024
    }

    RTC.CMP = RTC.CNT + ticks;
    RTC.INTCTRL |= 0x2;
    while (RTC.STATUS && RTC_CMPBUSY_bm); // wait for RTC.CMP sync, may not be necessary
    sleep_cpu();
    RTC.INTCTRL &= ~0x2;
    while (RTC.STATUS & RTC_CNTBUSY_bm); // avoid stale millis(), definitely necessary
}
``` 