### PR TITLE
more core_devices.h fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 megaavr/tools/python3/*
 *.pyc
 *.pyc
+.DS_Store

--- a/megaavr/cores/megatinycore/UART0.cpp
+++ b/megaavr/cores/megatinycore/UART0.cpp
@@ -82,7 +82,7 @@
 #else
               "rjmp   _do_rxc"    "\n\t"
 #endif
-              ::"z"(&Serial1));
+              ::"z"(&Serial0));
         __builtin_unreachable();
     }
   #endif

--- a/megaavr/cores/megatinycore/core_devices.h
+++ b/megaavr/cores/megatinycore/core_devices.h
@@ -1925,9 +1925,14 @@
   #endif
 
   /* ======= PORT ======= */
-  #if !defined(PORT_INT_0_bm) && defined(PORT_INT0_bm)
+
+/* commenting out for now - not sure what if anything should replace this but was hitting the #error I inserted because these are defined and being set as constants
+#if !defined(PORT_INT_0_bm) && defined(PORT_INT0_bm)
     #define PORT_INT_0_bm PORT_INT0_bm
   #elif defined(PORT_INT_0_bm)
+    #if defined(PORT_INT0_bm)
+      #error("FUBAR - will cause compile error below")
+    #endif
     deprecated_constant_name PORT_INT0_bm = PORT_INT_0_bm;
   #endif
 
@@ -2021,6 +2026,7 @@
     deprecated_constant_name PORT_INT7_bp = PORT_INT_7_bp;
   #endif
 
+ */
   #if !defined(PORT_ISC_0_bm) && defined(PORT_ISC0_bm)
     #define PORT_ISC_0_bm PORT_ISC0_bm
   #elif defined(PORT_ISC_0_bm)

--- a/megaavr/cores/megatinycore/core_devices.h
+++ b/megaavr/cores/megatinycore/core_devices.h
@@ -518,13 +518,17 @@
   // So they went ahead and made that change. That is what's called a "breaking change", really for no reason except codes style. Most companies even if they decided to go that route, would never do that without introducuing a compatibility layer.
   // That wanton disregard for backwards compatibility is not acceptable in an Arduino core nor in a commercial product.
   // Using the old names will produce warnings. These deprecated names should be fixed as support for these FOUR THOUSAND LINES of bandaids WILL BE REMOBVED in 1.6.0!
+#ifdef ENABLE_DEPRECATED_MICROCHIP_WARNINGS
   typedef const uint8_t __attribute__ ((deprecated("\nMicrochip changed the spelling of bits within a bitfiels (macros that end in the bitnumber followed by _bm or _bp), you are using the old name, ex PERIPH_BITFIRLD1_bm.\nYou should use PERIPH_BITFIELD_1_bm; we do not guarantee that this 4000-line bandaid will not be removed in the future.\r\nWhy did they do this? Beats me. Ask their support folks - if enough of us do it, they might hesitate next time they have the urge to mass rename things in their headers")))  deprecated_constant_name;
+#else
+    typedef const uint8_t deprecated_constant_name;
+#endif
 
   /* ======= ACs ======= */
   #if !defined(AC_HYSMODE_0_bm) && defined(AC_HYSMODE0_bm)
     #define AC_HYSMODE_0_bm AC_HYSMODE0_bm
   #elif defined(AC_HYSMODE_0_bm)
-    deprecated_constant_name AC_HYSMODE0_bm AC_HYSMODE_0_bm;
+    deprecated_constant_name AC_HYSMODE0_bm = AC_HYSMODE_0_bm;
   #endif
 
   #if !defined(AC_HYSMODE_0_bp) && defined(AC_HYSMODE0_bp)


### PR DESCRIPTION
guarded the warnings with #ifdef ENABLE_DEPRECATED_MICROCHIP_WARNINGS as a prelude to a solution to not trigger them from mTC code.

added a missing = sign

still hitting errors I don't understand in 2.0 (now released, no longer RC):
```
/Users/user/Documents/GitHub/megaTinyCore/megaavr/cores/megatinycore/core_devices.h:1931:30: error: expected unqualified-id before numeric constant
     deprecated_constant_name PORT_INT0_bm = PORT_INT_0_bm;
```