### PR TITLE
improve millis IRQ with asm

### DIFF
--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -174,24 +174,26 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
 
   #if (defined(MILLIS_USE_TIMERB0) || defined(MILLIS_USE_TIMERB1) || defined(MILLIS_USE_TIMERB2) || defined(MILLIS_USE_TIMERB3) || defined(MILLIS_USE_TIMERB4))
     __asm__ __volatile__(
-    "ld         r24,      X""\n\t" //
-    "subi       r24, %[DEC]""\n\t" //
+    "ld         r24,      X""\n\t" // X points to LSB of timer_millis, load the LSB
+    "subi       r24, %[DEC]""\n\t" // "decrement" (actually increment) it by the desired value
+    "st          X+,    r24""\n\t" // Load incremented value back to X, post-increment X
+    "ld         r24,      X""\n\t" // And so on
+    "sbci       r24,   0xFF""\n\t" //
     "st          X+,    r24""\n\t" //
     "ld         r24,      X""\n\t" //
-    "sbci       r24, %[DEC]""\n\t" //
+    "sbci       r24,   0xFF""\n\t" //
     "st          X+,    r24""\n\t" //
     "ld         r24,      X""\n\t" //
-    "sbci       r24, %[DEC]""\n\t" //
-    "st          X+,    r24""\n\t" //
-    "ld         r24,      X""\n\t" //
-    "sbci       r24, %[DEC]""\n\t" //
-    "st           X,    r24""\n\t" //
-    ::      "x" (&timer_millis),
+    "sbci       r24,   0xFF""\n\t" //
+    "st           X,    r24""\n\t" // Until all 4 bytes were handled
+    :
+    :  "x" (&timer_millis),
     #if(F_CPU>1000000)
-        [DEC] "M" (0xFF) // sub 0xFF is the same as to add 1
+      [DEC]  "M" (0xFF) // sub 0xFF is the same as to add 1
     #else // if it's 1<Hz, we set the millis timer to only overflow every 2 milliseconds, intentionally sacrificing resolution.
-        [DEC] "M" (0xFE) // sub 0xFE is the same as to add 2
+      [DEC]  "M" (0xFE) // sub 0xFE is the same as to add 2
     #endif
+    : "r24"   // clobber
     );
   #else
     #if defined(MILLIS_USE_TIMERRTC)

--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -173,11 +173,26 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
   // (volatile variables must be read from memory on every access)
 
   #if (defined(MILLIS_USE_TIMERB0) || defined(MILLIS_USE_TIMERB1) || defined(MILLIS_USE_TIMERB2) || defined(MILLIS_USE_TIMERB3) || defined(MILLIS_USE_TIMERB4))
-    #if (F_CPU > 2000000)
-      timer_millis++; // that's all we need to do!
-    #else
-      timer_millis += 2;
+    __asm__ __volatile__(
+    "ld         r24,      X""\n\t" //
+    "subi       r24, %[DEC]""\n\t" //
+    "st          X+,    r24""\n\t" //
+    "ld         r24,      X""\n\t" //
+    "sbci       r24, %[DEC]""\n\t" //
+    "st          X+,    r24""\n\t" //
+    "ld         r24,      X""\n\t" //
+    "sbci       r24, %[DEC]""\n\t" //
+    "st          X+,    r24""\n\t" //
+    "ld         r24,      X""\n\t" //
+    "sbci       r24, %[DEC]""\n\t" //
+    "st           X,    r24""\n\t" //
+    ::      "x" (&timer_millis),
+    #if(F_CPU>1000000)
+        [DEC] "M" (0xFF) // sub 0xFF is the same as to add 1
+    #else // if it's 1<Hz, we set the millis timer to only overflow every 2 milliseconds, intentionally sacrificing resolution.
+        [DEC] "M" (0xFE) // sub 0xFE is the same as to add 2
     #endif
+    );
   #else
     #if defined(MILLIS_USE_TIMERRTC)
       // if RTC is used as timer, we only increment the overflow count


### PR DESCRIPTION
Quick improvement for millis IRQ. Improves cycles and flash by about 5-15%

for comparison, that was the generated asm before (I wish I knew how to tell gcc that ram is more costly than register manipulation)

```
 8aa:	1f 92       	push	r1
 8ac:	0f 92       	push	r0
 8ae:	0f b6       	in	r0, 0x3f	; 63
 8b0:	0f 92       	push	r0
 8b2:	11 24       	eor	r1, r1
 8b4:	8f 93       	push	r24
 8b6:	9f 93       	push	r25
 8b8:	af 93       	push	r26
 8ba:	bf 93       	push	r27
 8bc:	80 91 a7 40 	lds	r24, 0x40A7	; 0x8040a7 <timer_millis>
 8c0:	90 91 a8 40 	lds	r25, 0x40A8	; 0x8040a8 <timer_millis+0x1>
 8c4:	a0 91 a9 40 	lds	r26, 0x40A9	; 0x8040a9 <timer_millis+0x2>
 8c8:	b0 91 aa 40 	lds	r27, 0x40AA	; 0x8040aa <timer_millis+0x3>
 8cc:	01 96       	adiw	r24, 0x01	; 1
 8ce:	a1 1d       	adc	r26, r1
 8d0:	b1 1d       	adc	r27, r1
 8d2:	80 93 a7 40 	sts	0x40A7, r24	; 0x8040a7 <timer_millis>
 8d6:	90 93 a8 40 	sts	0x40A8, r25	; 0x8040a8 <timer_millis+0x1>
 8da:	a0 93 a9 40 	sts	0x40A9, r26	; 0x8040a9 <timer_millis+0x2>
 8de:	b0 93 aa 40 	sts	0x40AA, r27	; 0x8040aa <timer_millis+0x3>
 8e2:	81 e0       	ldi	r24, 0x01	; 1
 8e4:	80 93 26 0b 	sts	0x0B26, r24	; 0x800b26 <__TEXT_REGION_LENGTH__+0x7e0b26>
 8e8:	bf 91       	pop	r27
 8ea:	af 91       	pop	r26
 8ec:	9f 91       	pop	r25
 8ee:	8f 91       	pop	r24
 8f0:	0f 90       	pop	r0
 8f2:	0f be       	out	0x3f, r0	; 63
 8f4:	0f 90       	pop	r0
 8f6:	1f 90       	pop	r1
 8f8:	18 95       	reti
```