### PR TITLE
fix the new millis asm for 2MHz (tested, was wrong, now correct). Boards.txt :-(

### DIFF
--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -10,7 +10,7 @@
 #________________________________________________________________________#
 #                                                                        #
 #  Copyright Spence Konde and other         ##        ###         #      #
-#  contributors 2018-2021                  #  #      #           ##      #
+#  contributors 2018-2022                  #  #      #           ##      #
 #  megaTinyCore is free software.    # #     #       ####         #      #
 #  (LGPL v2.1) see LICENSE.md and    # #    #    ##  #   #  ##    #      #
 #  License section of README.md       #    ####  ##   ###   ##   ###     #
@@ -19,7 +19,7 @@
 #  Now reformatted for easy navigation with text editing tools which     #
 #  have the zoomed out "minimap" that you can scroll through.            #
 #                                                                        #
-#  megaTinyCore 2.6.0-1 is being developed simultaneously with DxCore    #
+#  megaTinyCore 2.6.1 is being developed simultaneously with DxCore    #
 #  1.5.0. As the hardware is very similar, much code is shared, and that #
 #  is the version of DxCore most similar to this version of megaTinyCore #
 #                                                                        #
@@ -1033,6 +1033,7 @@ atxy4.menu.clock.10internal=10 MHz internal
 atxy4.menu.clock.8internal=8 MHz internal
 atxy4.menu.clock.5internal=5 MHz internal
 atxy4.menu.clock.4internal=4 MHz internal
+atxy4.menu.clock.2internal=2 MHz internal
 atxy4.menu.clock.1internal=1 MHz internal
 atxy4.menu.clock.20internaltuned=20 MHz internal - tuned
 atxy4.menu.clock.16internaltuned=16 MHz internal - tuned
@@ -1068,6 +1069,8 @@ atxy4.menu.clock.5internal.build.speed=5
 atxy4.menu.clock.5internal.build.clocksource=0
 atxy4.menu.clock.4internal.build.speed=4
 atxy4.menu.clock.4internal.build.clocksource=0
+atxy4.menu.clock.2internal.build.speed=2
+atxy4.menu.clock.2internal.build.clocksource=0
 atxy4.menu.clock.1internal.build.speed=1
 atxy4.menu.clock.1internal.build.clocksource=0
 atxy4.menu.clock.20extclock.build.speed=20
@@ -3868,6 +3871,7 @@ atx24o.menu.clocko.10internal=10 MHz internal
 atx24o.menu.clocko.8internal=8 MHz internal
 atx24o.menu.clocko.5internal=5 MHz internal
 atx24o.menu.clocko.4internal=4 MHz internal
+atx24o.menu.clocko.2internal=2 MHz internal
 atx24o.menu.clocko.1internal=1 MHz internal
 atx24o.menu.clocko.20internaltuned=20 MHz internal - tuned
 atx24o.menu.clocko.16internaltuned=16 MHz internal - tuned
@@ -3904,6 +3908,8 @@ atx24o.menu.clocko.5internal.build.speed=5
 atx24o.menu.clocko.5internal.build.clocksource=0
 atx24o.menu.clocko.4internal.build.speed=4
 atx24o.menu.clocko.4internal.build.clocksource=0
+atx24o.menu.clocko.2internal.build.speed=2
+atx24o.menu.clocko.2internal.build.clocksource=0
 atx24o.menu.clocko.1internal.build.speed=1
 atx24o.menu.clocko.1internal.build.clocksource=0
 atx24o.menu.clocko.20extclock.build.speed=20

--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -188,7 +188,7 @@ inline unsigned long microsecondsToMillisClockCycles(unsigned long microseconds)
     "st           X,    r24""\n\t" // Until all 4 bytes were handled
     :
     :  "x" (&timer_millis),
-    #if(F_CPU>1000000)
+    #if(F_CPU>2000000)
       [DEC]  "M" (0xFF) // sub 0xFF is the same as to add 1
     #else // if it's 1<Hz, we set the millis timer to only overflow every 2 milliseconds, intentionally sacrificing resolution.
       [DEC]  "M" (0xFE) // sub 0xFE is the same as to add 2


### PR DESCRIPTION
… a missing 2MHz on 3224

- the new millis() asm didn't look right for 2mhz. Went to test it, found the menu item wasn't present on the 3224 I was testing on. Fixed that. Will come back and do a pass making sure it is present everywhere.

After testing determined the conditional change was wrong and fixed it.

testing: before, millis incremented at half speed, delay(1000) in loop behaved strangely (alternate calls took longer) at 2mhz, normal at 4mhz. after: 2mhz and 4mhz behave similarly.