### PR TITLE
220918 docs & 2.6.0+ -> 2.6.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Improved flash footprint of serial significantly while adding features, wire can
 
 ## IMPORTANT WARNINGS
 
-### IDE 2.0.x unsupported. If you use it, use the release not an old RC: all versions prior to 2.0.0-RC9.2 known to have critical regressions.
+### IDE 2.0.x unsupported. If you use it, use the release not an old RC: all versions prior to 2.0.0-RC9.2 known to have critical regressions
 These bugs in the IDE prevent board settings from being correctly recognized. [This thread tracks known issues with 2.0 and workarounds](https://github.com/SpenceKonde/megaTinyCore/discussions/760). If you use unsupported software please reproduce all issues in 1.8.13 before reporting.
 
 V1.8.13 is the "golden version" and the only one I recommend. All the more recent ones gained bugs, and its the last version with a substantial improvement. Be aware it does have a vulnerable version of Log4J.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ## [Questions? Cases where you don't know whether the problem is in your code or the core? Things to show off?](https://github.com/SpenceKonde/megaTinyCore/discussions)
 We have a Github Discussions section now. When a problem is *definitely* a defect in the core, you will reduce the time taken to fix it if you create an issue, as I prioritize issues over catching up on discussions.
 
-### 2.6.0 is out - rejoice
+### 2.6.1 is out - rejoice
 Improved flash footprint of serial significantly while adding features, wire can wake slave from sleep without corrupting data, and much, much more, see [the Changelog](ChangeLog.md).
 
 ## IMPORTANT WARNINGS
 
-### IDE 2.0.x unsupported and all versions prior to 2.0.0-RC9.2 known to have critical regressions
-These bugs in the IDE prevent board settings from being correctly recognized. Pull-requests with workarounds to undocumented beta behaviour will not be accepted. [This thread tracks known issues with 2.0 and workarounds](https://github.com/SpenceKonde/megaTinyCore/discussions/760). If you use unsupported software please reproduce all issues in 1.8.13 before reporting.
+### IDE 2.0.x unsupported. If you use it, use the release not an old RC: all versions prior to 2.0.0-RC9.2 known to have critical regressions.
+These bugs in the IDE prevent board settings from being correctly recognized. [This thread tracks known issues with 2.0 and workarounds](https://github.com/SpenceKonde/megaTinyCore/discussions/760). If you use unsupported software please reproduce all issues in 1.8.13 before reporting.
 
 V1.8.13 is the "golden version" and the only one I recommend. All the more recent ones gained bugs, and its the last version with a substantial improvement. Be aware it does have a vulnerable version of Log4J.
 Prior to megaTinyCore 2.6.0, manual installation of megaTinyCore would cause V1.8.14 of the IDE to crash due to [this bug](https://github.com/arduino/Arduino/issues/11813) when you install the core manually in your arduino folder and not when you install the core via boards manager. If you are manually edit platform.txt with

--- a/megaavr/cores/megatinycore/core_parameters.h
+++ b/megaavr/cores/megatinycore/core_parameters.h
@@ -12,7 +12,7 @@
   // The whole purpose of this file is largely for for the purpose of being something that can be included anywhere to make sure we know what core we are
   // which becomes more and more important as more code is shared between the cores.
 
-  #define MEGATINYCORE "Unknown 2.6.0+"
+  #define MEGATINYCORE "Unknown 2.6.1+"
   #if !defined(MEGATINYCORE_NUM)
     #if !(defined(MEGATINYCORE_MAJOR) && defined(MEGATINYCORE_MINOR) && defined(MEGATINYCORE_PATCH) && defined(MEGATINYCORE_RELEASED))
       #warning "All of the version defines are missing, please correct your build environment; it is likely failing to define other critical values"

--- a/megaavr/extras/Ref_Serial.md
+++ b/megaavr/extras/Ref_Serial.md
@@ -110,7 +110,7 @@ These basic options all conveniently reside in a single register.
 The modern tinyAVR and AVR Dx-series parts have a number of additional features. A few of these were available on classic AVRs (and just not exposed), but most of them are new.
 to use these, they should be coombined with one of the optionsfrom the table above using the bitwise or operator. More than one of these modifiers can be used, though many of them do not make sense in combination. When using the two argument form of Serial.begin(), remember to pass the constant (such as SERIAL_8N1) not just a modifier.
 
-```
+```C
 Serial.begin(115200, (SERIAL_8N1 | SERIAL_TX_ONLY));
 Serial1.begin(9600, (SERIAL_HALF_DUPLEX | SERIAL_RS485));
 ```


### PR DESCRIPTION
Resubmitting and including a version number bump from 2.6.0 to 2.6.1 in core_parameters.h to trigger the regression tests.