### PR TITLE
Fix ADC1 initialization

### DIFF
--- a/megaavr/cores/megatinycore/wiring.c
+++ b/megaavr/cores/megatinycore/wiring.c
@@ -1713,25 +1713,25 @@ void __attribute__((weak)) init_ADC0() {
   __attribute__((weak)) void init_ADC1() {
     //                              30 MHz / 32 = 937 kHz,  32 MHz / 32 =  1 MHz.
     #if   F_CPU   > 24000000     // 24 MHz / 16 = 1.5 MHz,  25 MHz / 32 =  780 kHz
-      ADC0.CTRLC  = ADC_PRESC_DIV32_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
+      ADC1.CTRLC  = ADC_PRESC_DIV32_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
     #elif F_CPU  >= 12000000    // 16 MHz / 16 = 1.0 MHz,  20 MHz / 16 = 1.25 MHz
-      ADC0.CTRLC  = ADC_PRESC_DIV16_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
+      ADC1.CTRLC  = ADC_PRESC_DIV16_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
     #elif F_CPU  >=  6000000    //  8 MHz /  8 = 1.0 MHz,  10 MHz /  8 = 1.25 MHz
-      ADC0.CTRLC  =  ADC_PRESC_DIV8_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
+      ADC1.CTRLC  =  ADC_PRESC_DIV8_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
     #elif F_CPU  >=  3000000    //  4 MHz /  4 = 1.0 MHz,   5 MHz /  4 = 1.25 MHz
-      ADC0.CTRLC  =  ADC_PRESC_DIV4_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
+      ADC1.CTRLC  =  ADC_PRESC_DIV4_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
     #else                       //  1 MHz /  2 = 500 kHz - the lowest setting
-      ADC0.CTRLC  =  ADC_PRESC_DIV2_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
+      ADC1.CTRLC  =  ADC_PRESC_DIV2_gc | ADC_REFSEL_VDDREF_gc | ADC_SAMPCAP_bm;
     #endif
     #if   (F_CPU == 6000000 || F_CPU == 12000000 || F_CPU == 24000000 || F_CPU ==25000000)
-      ADC0.SAMPCTRL = (7); // 9 ADC clocks, 12 us
+      ADC1.SAMPCTRL = (7); // 9 ADC clocks, 12 us
     #elif (F_CPU == 5000000 || F_CPU == 10000000 || F_CPU == 20000000)
-      ADC0.SAMPCTRL = (13);   // 15 ADC clock,s 12 us
+      ADC1.SAMPCTRL = (13);   // 15 ADC clock,s 12 us
     #else
-      ADC0.SAMPCTRL = (10); // 12 ADC clocks, 12 us
+      ADC1.SAMPCTRL = (10); // 12 ADC clocks, 12 us
     #endif
-    ADC0.CTRLD    = ADC_INITDLY_DLY16_gc;
-    ADC0.CTRLA    = ADC_ENABLE_bm;
+    ADC1.CTRLD    = ADC_INITDLY_DLY16_gc;
+    ADC1.CTRLA    = ADC_ENABLE_bm;
   }
 #endif
 


### PR DESCRIPTION
I am trying to use ADC1 on an ATtiny1616. While debugging my program (in)operation, I realized that ADC1 isn't enabled. I noticed that `init_ADC1()` is defined, but it was referring to ADC0 registers. That's now fixed. Additionally, `init_ADC1()` is now called if the peripheral is present.

This of course isn't a complete implementation of ADC1 support; no `analogReference()` or `analogRead()` implementations are defined. I created my custom implementations for them.