### PR TITLE
Configure "Compile Examples" workflow for authenticated API requests

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -229,6 +229,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
 
@@ -261,6 +262,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (TCB0 millis)
@@ -291,6 +293,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (RTC millis)
@@ -321,6 +324,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (default millis, 8 MHz)
@@ -350,6 +354,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (default millis, clock 25 MHz internal, tuned)
@@ -380,6 +385,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (default millis, clock 24 MHz external)
@@ -410,6 +416,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (default millis, clock 8 MHz internal, tuned)
@@ -440,6 +447,7 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports
       - name: Compile examples (default millis, clock 1 MHz internal, tuned)
@@ -470,5 +478,6 @@ jobs:
             -
           verbose: false
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-warnings-report: true
           sketches-report-path: sketches-reports


### PR DESCRIPTION
[The `arduino/compile-sketches` GitHub Actions action](https://github.com/arduino/compile-sketches) used in the "Compile Examples" [workflow](https://docs.github.com/actions/using-workflows/about-workflows) queries [the GitHub API](https://docs.github.com/en/rest) for the base ref of the pull request, which is used for the [memory deltas determination](https://github.com/arduino/compile-sketches#enable-deltas-report).

GitHub does [rate limiting of API requests](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) and if the limit is exceeded, a spurious failure of the workflow run will occur, as was happening previously ([example](https://github.com/SpenceKonde/megaTinyCore/actions/runs/3858167935)).

Authenticated API requests are given a more generous API request allowance, so providing the action with [the automatically generated GitHub access token stored in `secrets.GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to use for the API requests should prevent any further workflow run failures caused by rate limiting.