### PR TITLE
Serial1 swap is broken on 20/24 pin 2 series. Updated HardwareSerial.h

### DIFF
--- a/megaavr/cores/megatinycore/HardwareSerial.h
+++ b/megaavr/cores/megatinycore/HardwareSerial.h
@@ -25,6 +25,7 @@
              so whenever UART.h has been loaded, those three macros are defined as either 1, or wharever
              value the user overode them with, likely 0. Also high byte of UART address always 0x08, so replace
              2-clock ldd with 1 clock ldi. - Spence
+ * 03/12/23: Correct bug in TxD1' and XCK1'
 */
 
 #pragma once
@@ -211,7 +212,7 @@ const uint8_t _usart_pins[][4] = {{PIN_PB2, PIN_PB3, PIN_PB1, PIN_PB0},{PIN_PA1,
 const uint8_t _usart_pins[][4] = {
   {PIN_PB2, PIN_PB3, PIN_PB1, PIN_PB0},
   {PIN_PA1, PIN_PA2, PIN_PA3, PIN_PA4},
-  {PIN_PC0, PIN_PC1, PIN_PC2, PIN_PC3}
+  {PIN_PC2, PIN_PC1, PIN_PC1, PIN_PC3}
 };
 #else
   #error "This can't happen - it doesn't have 8, 14, 20 or 24 pins, or it has 14 pins but no serial port - defines aren't being picked up correctly."


### PR DESCRIPTION
Serial1 swap was broken, corrected mux pins:

```
const uint8_t _usart_pins[][4] = {
  {PIN_PB2, PIN_PB3, PIN_PB1, PIN_PB0},
  {PIN_PA1, PIN_PA2, PIN_PA3, PIN_PA4},
  {PIN_PC0, PIN_PC1, PIN_PC2, PIN_PC3} 
```
Should be:
```
const uint8_t _usart_pins[][4] = {
  {PIN_PB2, PIN_PB3, PIN_PB1, PIN_PB0},
  {PIN_PA1, PIN_PA2, PIN_PA3, PIN_PA4},
  {PIN_PC2, PIN_PC1, PIN_PC0, PIN_PC3} 
```
TxD1' and XCK1' were switched.
See "Table 3-1. PORT Function Multiplexing" of the ATtiny3224/3226/3227 datasheet (and the datasheets of the others from the 2 series).

Test code:
```
#define SWAP_PORT 1
Serial0.swap(SWAP_PORT);
Serial0.begin(115200, (SERIAL_8N1));
Serial1.swap(SWAP_PORT);
Serial1.begin(115200, (SERIAL_8N1));
Serial0.println("serial0test");
Serial1.println("serial1test");

```
The above code will work with SWAP_PORT 0, but not with 1. After the modification, it will work.
