### PR TITLE
ATtiny814 - Fix PWM output for WO0 & WO2

### DIFF
--- a/megaavr/cores/megatinycore/wiring_analog.c
+++ b/megaavr/cores/megatinycore/wiring_analog.c
@@ -1133,9 +1133,13 @@ void analogWrite(uint8_t pin, int val) {
         #else
           //Otherwise, we're in split mode and we use the classical method.
           volatile uint8_t *timer_cmp_out; // must be volatile for this to be safe.
-          #ifdef __AVR_ATtinyxy2__
-            if (bit_mask == 0x80) {
-              bit_mask = 1;  // on the xy2, WO0 is on PA7
+          #if defined(_TCA_ALT_WO0)
+            if (bit_mask == PIN3_bm) {
+              bit_mask = PIN0_bm;
+            }
+          #elif defined(__AVR_ATtinyxy2__)
+            if (bit_mask == PIN7_bm) {
+              bit_mask = PIN0_bm;  // on the xy2, WO0 is on PA7
             }
           #endif
           uint8_t offset = 0;

--- a/megaavr/cores/megatinycore/wiring_digital.c
+++ b/megaavr/cores/megatinycore/wiring_digital.c
@@ -122,9 +122,13 @@ void turnOffPWM(uint8_t pin)
       #if !defined(TCA_BUFFERED_3PIN)
         // uint8_t *timer_cmp_out;
         /* Bit position will give output channel */
-        #ifdef __AVR_ATtinyxy2__
-          if (bit_mask == 0x80) {
-            bit_mask = 1;         // on the xy2, WO0 is on PA7
+        #if defined(_TCA_ALT_WO0)
+          if (bit_mask == PIN3_bm) {
+            bit_mask = PIN0_bm;
+          }
+        #elif defined(__AVR_ATtinyxy2__)
+          if (bit_mask == PIN7_bm) {
+            bit_mask = PIN0_bm;         // on the xy2, WO0 is on PA7
           }
           if (bit_mask > 0x04) {  // -> bit_pos > 2 -> output channel controlled by HCMP
             bit_mask <<= 1;       // mind the gap (between LCMP and HCMP)

--- a/megaavr/variants/txy4/pins_arduino.h
+++ b/megaavr/variants/txy4/pins_arduino.h
@@ -296,20 +296,20 @@ const uint8_t digital_pin_to_timer[] = {
   #endif
   NOT_ON_TIMER,       // 3  PA7
   #if defined(_TCA_ALT_WO0)
-    TIMERA0,          // 6  PB3 WO0
+    TIMERA0,          // 4  PB3 WO0
   #else
-    NOT_ON_TIMER,     // 6  PB3 WO0
+    NOT_ON_TIMER,     // 4  PB3 WO0
   #endif
-  #if !defined(_TCA_ALT_WO0)
-    TIMERA0,          // 6  PB3 WO0
+  #if !defined(_TCA_ALT_WO2)
+    TIMERA0,          // 5  PB2 WO2
   #else
-    NOT_ON_TIMER,     // 6  PB3 WO0
+    NOT_ON_TIMER,     // 5  PB2 WO2
   #endif
   // Right side, bottom to top
-  #if !defined(_TCA_ALT_WO0)
-    TIMERA0,          // 6  PB3 WO0
+  #if !defined(_TCA_ALT_WO1)
+    TIMERA0,          // 6  PB1 WO1
   #else
-    NOT_ON_TIMER,     // 6  PB3 WO0
+    NOT_ON_TIMER,     // 6  PB1 WO1
   #endif
   #if !defined(_TCA_ALT_WO0)
     TIMERA0,          // 7  PB0 WO0 Alt


### PR DESCRIPTION
### Context
I wanted to build the [Adafruit Seesaw Peripheral](https://github.com/adafruit/Adafruit_seesawPeripheral) project on an ATtiny814, but the PWM function of PB3 was not working; it's the alternate PIN for WO0.

I forked the repo and saw major changes since the official release of 1.6.5 in this area. This looked promising.

### Changes
I fixed some copy-paste errors and added a check in `analogWrite` and `digitalWrite` to handle this special case.

### Side note
I'm also thinking of adding another lookup table describing the relationof `pin number` to `TCA output`. As of right now, it is computed, but adding alternate pin functionality may complicate this code too much:
```c
uint8_t offset = 0;
if (bit_mask > 0x04) { // HCMP
  bit_mask <<= 1;      // mind the gap
  offset = 1;          // if it's an hcmp, the offset of the compare register is 1 higher.
}
if      (bit_mask & 0x44) offset += 4;
else if (bit_mask & 0x22) offset += 2;
timer_cmp_out = ((volatile uint8_t *)(&TCA0.SPLIT.LCMP0)) + (offset); //finally at the very end we get the actual pointer (since volatile variables should be treated like nuclear waste due to performance impact)
(*timer_cmp_out) = (val); // write to it - and we're done with it.
TCA0.SPLIT.CTRLB |= bit_mask;
```

I could make another PR with this change if the proposed solution is acceptable.