### PR TITLE
Add option to enable XDIR pin for RS485 mode

### DIFF
--- a/megaavr/bootloaders/optiboot_x/optiboot_x.c
+++ b/megaavr/bootloaders/optiboot_x/optiboot_x.c
@@ -401,6 +401,9 @@ int main(void) {
 
   MYUART_TXPORT.DIR |= MYUART_TXPIN; // set TX pin to output
   MYUART_TXPORT.OUT |= MYUART_TXPIN;  // and "1" as per datasheet
+  #if RS485 > 0
+    MYUART_XDIRPORT.DIR |= MYUART_XDIRPIN; // set XDIR pin to output
+  #endif
   #if defined (MYUART_PMUX_VAL)
     MYPMUX_REG = MYUART_PMUX_VAL;  // alternate pinout to use
   #endif
@@ -411,7 +414,12 @@ int main(void) {
   }
   MYUART.DBGCTRL = 1;  // run during debug
   MYUART.CTRLC = (USART_CHSIZE_gm & USART_CHSIZE_8BIT_gc);  // Async, Parity Disabled, 1 StopBit
-  MYUART.CTRLA = 0;  // Interrupts: all off
+  #if RS485 > 0
+    /* Enable RS485 mode using XDIR pin */
+    MYUART.CTRLA = 1;  // Interrupts: all off, RS485 mode 1
+  #else
+    MYUART.CTRLA = 0;  // Interrupts: all off, RS485 off
+  #endif
   MYUART.CTRLB = USART_RXEN_bm | USART_TXEN_bm;
 
   // Set up watchdog to trigger after a bit

--- a/megaavr/bootloaders/optiboot_x/optiboot_x.c
+++ b/megaavr/bootloaders/optiboot_x/optiboot_x.c
@@ -731,6 +731,10 @@ void watchdogConfig(uint8_t x) {
   #ifdef UARTTX
     OPTFLASHSECT const char f_uart[] = "UARTTX=" UART_NAME;
   #endif
+  
+  #ifdef RS485
+    OPT2FLASH(RS485);
+  #endif
 
   OPTFLASHSECT const char f_date[] = "Built:" __DATE__ ":" __TIME__;
   #ifdef BIGBOOT

--- a/megaavr/bootloaders/optiboot_x/optiboot_x.c
+++ b/megaavr/bootloaders/optiboot_x/optiboot_x.c
@@ -731,7 +731,6 @@ void watchdogConfig(uint8_t x) {
   #ifdef UARTTX
     OPTFLASHSECT const char f_uart[] = "UARTTX=" UART_NAME;
   #endif
-  
   #ifdef RS485
     OPT2FLASH(RS485);
   #endif

--- a/megaavr/bootloaders/optiboot_x/parse_options.mk
+++ b/megaavr/bootloaders/optiboot_x/parse_options.mk
@@ -119,6 +119,12 @@ SS_CMD = -DSINGLESPEED=1
 endif
 endif
 
+HELPTEXT += "Option RS485=1               - use RS485 mode for UART, controlled by XDIR pin\n"
+ifdef RS485
+ifneq ($(RS485), 0)
+RS485_CMD = -DRS485=1
+endif
+endif
 
 #CPU Options
 
@@ -157,4 +163,4 @@ ifdef UARTTX
 UART_CMD = -DUARTTX=$(UARTTX)
 endif
 
-UART_OPTIONS = $(UART_CMD) $(BAUD_RATE_CMD) $(SOFT_UART_CMD) $(SS_CMD)
+UART_OPTIONS = $(UART_CMD) $(BAUD_RATE_CMD) $(SOFT_UART_CMD) $(SS_CMD) $(RS485_CMD)

--- a/megaavr/bootloaders/optiboot_x/pin_defs_x.h
+++ b/megaavr/bootloaders/optiboot_x/pin_defs_x.h
@@ -824,10 +824,10 @@
 
 #if defined(__AVR_ATtiny3227__) || defined(__AVR_ATtiny827__) || \
     defined(__AVR_ATtiny1627__) || defined(__AVR_ATtiny427__) || \
-    defined(__AVR_ATtiny3226__) || defined(__AVR_ATtiny827__) || \
-    defined(__AVR_ATtiny1626__) || defined(__AVR_ATtiny427__) || \
-    defined(__AVR_ATtiny3224__) || defined(__AVR_ATtiny827__) || \
-    defined(__AVR_ATtiny1624__) || defined(__AVR_ATtiny427__)
+    defined(__AVR_ATtiny3226__) || defined(__AVR_ATtiny826__) || \
+    defined(__AVR_ATtiny1626__) || defined(__AVR_ATtiny426__) || \
+    defined(__AVR_ATtiny3224__) || defined(__AVR_ATtiny824__) || \
+    defined(__AVR_ATtiny1624__) || defined(__AVR_ATtiny424__)
 #define MYPMUX_REG PORTMUX.USARTROUTEA
 # if (UARTTX == B2)
 #  define UART_NAME "B2"

--- a/megaavr/bootloaders/optiboot_x/pin_defs_x.h
+++ b/megaavr/bootloaders/optiboot_x/pin_defs_x.h
@@ -678,6 +678,7 @@
 
 /*
  * Handle devices with up to 4 uarts.  Rather inelegantly.
+ *  There is no alternative XDIR pin for USART2 and USART3.
  */
 #define USART_ALTPMUX 1
 
@@ -694,6 +695,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1<<PORT0)
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART0_DEFAULT_gc)
 # elif (UARTTX == A4)
 #  define UART_NAME "A4"
@@ -703,6 +706,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1<<PORT4)
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT7)
 #  define MYUART_PMUX_VAL (PORTMUX_USART0_ALT1_gc)
 # elif (UARTTX == B0)
 #  define UART_NAME "B0"
@@ -712,6 +717,8 @@
 #  define MYUART USART3
 #  define MYUART_TXPORT VPORTB
 #  define MYUART_TXPIN (1<<PORT0)
+#  define MYUART_XDIRPORT VPORTB
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART3_DEFAULT_gc)
 # elif (UARTTX == B4)
 #  define UART_NAME "B4"
@@ -721,6 +728,8 @@
 #  define MYUART USART3
 #  define MYUART_TXPORT VPORTB
 #  define MYUART_TXPIN (1<<PORT4)
+#  define MYUART_XDIRPORT VPORTB
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART3_ALT1_gc)
 # elif (UARTTX == C0)
 #  define UART_NAME "C0"
@@ -730,6 +739,8 @@
 #  define MYUART USART1
 #  define MYUART_TXPORT VPORTC
 #  define MYUART_TXPIN (1<<PORT0)
+#  define MYUART_XDIRPORT VPORTC
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART1_DEFAULT_gc)
 # elif (UARTTX == C4)
 #  define UART_NAME "C4"
@@ -739,6 +750,8 @@
 #  define MYUART USART1
 #  define MYUART_TXPORT VPORTC
 #  define MYUART_TXPIN (1<<PORT4)
+#  define MYUART_XDIRPORT VPORTC
+#  define MYUART_XDIRPIN (1<<PORT7)
 #  define MYUART_PMUX_VAL (PORTMUX_USART1_ALT1_gc)
 # elif (UARTTX == F0)
 #  define UART_NAME "F0"
@@ -748,6 +761,8 @@
 #  define MYUART USART2
 #  define MYUART_TXPORT VPORTF
 #  define MYUART_TXPIN (1<<PORT0)
+#  define MYUART_XDIRPORT VPORTF
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART2_DEFAULT_gc)
 # elif (UARTTX == F4)
 #  define UART_NAME "F4"
@@ -757,12 +772,16 @@
 #  define MYUART USART2
 #  define MYUART_TXPORT VPORTF
 #  define MYUART_TXPIN (1<<PORT4)
+#  define MYUART_XDIRPORT VPORTF
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (PORTMUX_USART2_ALT1_gc)
 # endif
 #endif  // ATmega4809
 
 /*
  * 8pin Tiny0 and Tiny1
+ *  There is no alternative XDIR pin. On the 412/212, there is no
+ *  XDIR pin at all!
  */
 #if defined(__AVR_ATtiny402__) || defined(__AVR_ATtiny202__) || \
     defined(__AVR_ATtiny412__) || defined(__AVR_ATtiny212__)
@@ -775,6 +794,11 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1<<PORT6)
+#  if (RS485 > 0) && (defined(__AVR_ATtiny412__) || defined(__AVR_ATtiny212__))
+#   error XDIR pin not available on ATtiny412 and ATtiny212
+#  endif
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT0)
 #  define MYUART_PMUX_VAL 0
 # elif (UARTTX == A1)
 #  define UART_NAME "A1"
@@ -784,6 +808,11 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1<<PORT1)
+#  if (RS485 > 0) && (defined(__AVR_ATtiny412__) || defined(__AVR_ATtiny212__))
+#   error XDIR pin not available on ATtiny412 and ATtiny212
+#  endif
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT0)
 #  define MYUART_PMUX_VAL (USART_ALTPMUX)
 # endif
 #endif // Tiny402/etc
@@ -809,6 +838,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTB
 #  define MYUART_TXPIN (1<<PORT2)
+#  define MYUART_XDIRPORT VPORTB
+#  define MYUART_XDIRPIN (1<<PORT0)
 #  define MYUART_PMUX_VAL 0
 # elif (UARTTX == A1)
 #  define UART_NAME "A1"
@@ -818,6 +849,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1<<PORT1)
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT4)
 #  define MYUART_PMUX_VAL (USART_ALTPMUX)
 # endif
 #endif
@@ -837,6 +870,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTB
 #  define MYUART_TXPIN (1 << PORT2)
+#  define MYUART_XDIRPORT VPORTB
+#  define MYUART_XDIRPIN (1<<PORT0)
 #  define MYUART_PMUX_VAL 0
 # elif (UARTTX == A1)
 #  define UART_NAME "A1"
@@ -846,6 +881,8 @@
 #  define MYUART USART0
 #  define MYUART_TXPORT VPORTA
 #  define MYUART_TXPIN (1 << PORT1)
+#  define MYUART_XDIRPORT VPORTA
+#  define MYUART_XDIRPIN (1<<PORT4)
 #  define MYUART_PMUX_VAL (USART_ALTPMUX)
 # elif (UARTTX == C2)
 #  define UART_NAME "C2"
@@ -855,6 +892,8 @@
 #  define MYUART USART1
 #  define MYUART_TXPORT VPORTC
 #  define MYUART_TXPIN (1 << PORT2)
+#  define MYUART_XDIRPORT VPORTC
+#  define MYUART_XDIRPIN (1<<PORT3)
 #  define MYUART_PMUX_VAL (USART_ALTPMUX << 2)
 # endif
 #endif


### PR DESCRIPTION
I've added an option to enable RS485 mode 1 on the UART so that the XDIR pin can be used to control an external RS485 transceiver. Unlikely to be useful if you have more than one device on the network, but great for remotely flashing hard-to-access devices that you would otherwise need to physically get to.

With a suitable USB RS485 cable that automatically drives the bus without fancy RTS signaling, everything works (avrdude/Arduino upload) without any additional modification. You will of course need to figure out how to enter the bootloader remotely.

This change increases the bootloader size by an additional instruction to set the XDIR pin to output. For BIGBOOT, it also embeds the RS485 parameter.