### PR TITLE
changed access specifier in tinyNeoPixel libs from private to protect…

### DIFF
--- a/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.h
+++ b/megaavr/libraries/tinyNeoPixel/tinyNeoPixel.h
@@ -321,7 +321,7 @@ class tinyNeoPixel {
   #endif
 
 
- private:
+ protected:
 
   boolean
     begun;         // true if begin() previously called

--- a/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.h
+++ b/megaavr/libraries/tinyNeoPixel_Static/tinyNeoPixel_Static.h
@@ -305,7 +305,7 @@ class tinyNeoPixel {
   #endif
 
 
- private:
+ protected:
 
   uint16_t
     numLEDs,       // Number of RGB LEDs in strip


### PR DESCRIPTION
changed access specifier in tinyNeoPixel libs from private to protected so inheriting classes have access to important variables. See issue #1103.