### PR TITLE
Fix pin assignment to use TUNING_PIN define

### DIFF
--- a/megaavr/libraries/megaTinyCore/examples/megaTinyTuner/megaTinyTuner.ino
+++ b/megaavr/libraries/megaTinyCore/examples/megaTinyTuner/megaTinyTuner.ino
@@ -217,7 +217,7 @@ void loop() {
           while (i < 8)
         #endif
         {
-          uint16_t temp = pulseIn(PIN_PA5, LOW, (uint32_t) 100000UL);
+          uint16_t temp = pulseIn(TUNING_PIN, LOW, (uint32_t) 100000UL);
           #if defined(ONEKHZMODE)
             if (temp < 200 || temp > 1000)
           #else


### PR DESCRIPTION
Currently the `TUNING_PIN` pin define is unused, and the `pulseIn()` function uses a hard coded value, 