### PR TITLE
Fix hang in Serial.flush()

### DIFF
--- a/megaavr/cores/megatinycore/UART.cpp
+++ b/megaavr/cores/megatinycore/UART.cpp
@@ -728,7 +728,7 @@
         // If we have never written a byte, no need to flush. This special
         // case is needed since there is no way to force the TXCIF (transmit
         // complete) bit to 1 during initialization
-        if (!_state & 1) {
+        if (!(_state & 1)) {
           return;
         }
 


### PR DESCRIPTION
_state will be 0x2 for half-duplex mode, so we need to be careful with operator precedence to test only the low bit. Without this change, Serial.flush() hangs when half-duplex is enabled and no data has yet been sent.