### PR TITLE
Fix typos relating to TCD usage, document WOC and WOD

### DIFF
--- a/megaavr/cores/megatinycore/Arduino.h
+++ b/megaavr/cores/megatinycore/Arduino.h
@@ -568,7 +568,7 @@ uint32_t microsecondsToMillisClockCycles(uint32_t microseconds);
 
 
 // 0b01MC 0mmm - the 3 lowest bits refer to the PORTMUX.
-//                            bit C specifies whether it's channel A (0) or B (1). If M is 1 it is WOC outputting chan A or WOB outputting D.
+//                            bit C specifies whether it's channel A (0) or B (1). If M is 1 it is WOC outputting chan A or WOD outputting B.
 //                            WOD outputting A or WOC outputting B is not supported by the core. WOB outputting A or WOA outputting B is not supported by the hardware.
 //                            Hence, PORTMUX.TCDROUTEA == (timer table entry) & (0x07)
 //                            and any table entry > 0x40 but less than 0x80 could be a TCD

--- a/megaavr/extras/Ref_TCD.md
+++ b/megaavr/extras/Ref_TCD.md
@@ -11,7 +11,7 @@ In addition to the synchronization, some of the intentional features make it cha
 ```c++
 analogWrite(PIN_PA4,128); // 50% PA4. - like usual
 analogWrite(PIN_PA7,192); // 50% PA4, 75% PA7 - like usual
-analogWrite(PIN_PA6, 64); // 25% PA5, 25% PA6, 75% PA7 - PA4 and PA6 are both channel A
+analogWrite(PIN_PA6, 64); // 25% PA4, 25% PA6, 75% PA7 - PA4 and PA6 are both channel A
 //use digitalWrite to turn off the PWM on a pin
 // or call turnOffPwm(pin);
 ```

--- a/megaavr/extras/Ref_TCD.md
+++ b/megaavr/extras/Ref_TCD.md
@@ -16,6 +16,10 @@ analogWrite(PIN_PA6, 64); // 25% PA4, 25% PA6, 75% PA7 - PA4 and PA6 are both ch
 // or call turnOffPwm(pin);
 ```
 
+## WOC and WOD (PC0 and PC1)
+
+On 20/24 pin 1-Series parts, `TCD0` can also drive the `WOC` and `WOD` pins (PC0 and PC1 respectively). `WOC` and `WOD` can each be connected to either `WOA` or `WOB`, but the core only supports connecting `WOC` to `WOA` and `WOD` to `WOB`.
+
 ## Permitted settings
 You can do the following things and continue using analogWrite() and expect it to keep behaving normally. Do not expect anything else to work - if you need to do more, you need to take it over entirely.
 


### PR DESCRIPTION
Fixes a couple of (what I think are) typos in comments relating to WOC and WOD, and also attempts to document these outputs on the TCD0 page.