### PR TITLE
Extension to include debugging support 

### DIFF
--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -16,7 +16,7 @@ version={versionnum.major}.{versionnum.minor}.{versionnum.patch}{versionnum.post
 # Stupid workaround #
 # for IDE bug       #
 #####################
-version=2.6.11
+version=2.7.0-pre1
 
 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DMEGATINYCORE="{version}" -DMEGATINYCORE_MAJOR={versionnum.major}UL -DMEGATINYCORE_MINOR={versionnum.minor}UL -DMEGATINYCORE_PATCH={versionnum.patch}UL -DMEGATINYCORE_RELEASED={versionnum.released}
 
@@ -25,6 +25,14 @@ build.optiondefines=-DF_CPU={build.f_cpu} -DCLOCK_SOURCE={build.clocksource} -DT
 #########################
 # AVR compile variables #
 #########################
+
+# Optimization flags for debugging
+# The {build.relax} flags can be added to the release
+# optimization flags. However, they make debugging impossible
+# because -mrelax distorts the line numbering.
+compiler.optimization_flags=-Os -ggdb3 -flto -DNDEBUG
+compiler.optimization_flags.release=-Os -ggdb3 -flto -DNDEBUG
+compiler.optimization_flags.debug=-Og -ggdb3 -fno-lto -DLTODISABLED -DDEBUG
 
 compiler.warning_flags=-Wall
 compiler.warning_flags.none=-Wall
@@ -35,12 +43,12 @@ compiler.warning_flags.all=-Wall -Wextra
 # Default "compiler.path" is correct, change only if you want to override the initial value
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
-compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects {build.mrelax} -Werror=implicit-function-declaration -Wundef
-compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start} {build.mrelax}
+compiler.c.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -fno-fat-lto-objects  -Werror=implicit-function-declaration -Wundef
+compiler.c.elf.flags={compiler.warning_flags} {compiler.optimization_flags}  -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start} 
 compiler.c.elf.cmd=avr-gcc
-compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
+compiler.S.flags=-c {compiler.optimization_flags} -x assembler-with-cpp -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++17 -fpermissive -Wno-sized-deallocation -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto {build.mrelax}
+compiler.cpp.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++17 -fpermissive -Wno-sized-deallocation -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD 
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
@@ -240,3 +248,26 @@ tools.serialupdi.bootloader.pattern="{cmd}" -u "{runtime.platform.path}/tools/pr
 # bootloader being erased but no sketches working)
 
 tools.serialupdi.program.pattern={upload.prog_interlock}"{cmd}" -u "{runtime.platform.path}/tools/prog.py"  -t {protocol} {program.extra_params} -d {build.mcu}{upload.workaround} --fuses 0:{bootloader.WDTCFG} 2:{bootloader.OSCCFG} 6:{bootloader.SYSCFG1} 7:{bootloader.APPEND} 8:{bootloader.BOOTEND} "-f{build.path}/{build.project_name}.hex" -a write {program.verbose}
+
+# Debugger configuration (general options)
+# ----------------------------------------
+debug.executable={build.path}/{build.project_name}.elf
+debug.toolchain=gcc
+debug.toolchain.path={runtime.tools.avrocd-tools.path}
+debug.server=openocd
+debug.server.openocd.path={debug.toolchain.path}/pyavrocd
+#next doesn't matter, but should be specified so that cortex-debug is happy
+debug.server.openocd.script=nix
+debug.cortex-debug.custom.gdbPath={debug.toolchain.path}/avr-gdb
+debug.cortex-debug.custom.overrideGDBServerStartedRegex=Listening on port \d+ for gdb connection
+debug.cortex-debug.custom.objdumpPath={runtime.tools.avr-gcc.path}/bin/avr-objdump
+debug.cortex-debug.custom.serverArgs.0=-s
+debug.cortex-debug.custom.serverArgs.1=nop
+debug.cortex-debug.custom.serverArgs.2=-d
+debug.cortex-debug.custom.serverArgs.3={build.mcu}
+debug.cortex-debug.custom.serverArgs.4=--manage
+debug.cortex-debug.custom.serverArgs.5=all
+debug.cortex-debug.custom.serverArgs.6=--F_CPU
+debug.cortex-debug.custom.serverArgs.7={build.f_cpu}
+debug.cortex-debug.custom.runToEntryPoint=main
+debug.svd_file={debug.toolchain.path}/pyavrocd-util/svd/{build.mcu}.svd

--- a/megaavr/programmers.txt
+++ b/megaavr/programmers.txt
@@ -76,7 +76,7 @@ medbg.program.protocol=xplainedmini_updi
 medbg.program.tool=avrdude
 medbg.program.extra_params=-Pusb
 
-atmelice_updi.name=Atmel-ICE
+atmelice_updi.name=Atmel-ICE  (UPDI mode)
 atmelice_updi.communication=usb
 atmelice_updi.protocol=atmelice_updi
 atmelice_updi.program.protocol=jtagice3_updi
@@ -96,3 +96,17 @@ snap_updi.protocol=snap_updi
 snap_updi.program.protocol=jtagice3_updi
 snap_updi.program.tool=avrdude
 snap_updi.program.extra_params=-Pusb
+
+jtagice3_updi.name=JTAGICE3 (UPDI mode)
+jtagice3_updi.communication=usb
+jtagice3_updi.protocol=jtag3updi
+jtagice3_updi.program.protocol=jtag3updi
+jtagice3_updi.program.tool=avrdude
+jtagice3_updi.program.extra_params=
+
+atmel_powerdebugger_updi.name=Power Debugger (UPDI mode)
+atmel_powerdebugger_updi.communication=usb
+atmel_powerdebugger_updi.protocol=powerdebugger_updi
+atmel_powerdebugger_updi.program.protocol=powerdebugger_updi
+atmel_powerdebugger_updi.program.tool=avrdude
+atmel_powerdebugger_updi.program.extra_params=


### PR DESCRIPTION
This PR adds support for debugging provided by [PyAvrOCD](https://pyavrocd.io) to megaTinyCore. In addition to this PR, you need to include the tool package pyavrocd in the boards manager index file. See the end of https://felias-fogg.github.io/megaTinyCore/package_SpenceKonde_megaTinyCore_index.json for an example. 