### PR TITLE
Enabling debugging in the Arduino IDE 2

### DIFF
--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -16,7 +16,7 @@ version={versionnum.major}.{versionnum.minor}.{versionnum.patch}{versionnum.post
 # Stupid workaround #
 # for IDE bug       #
 #####################
-version=2.6.11
+version=2.7.0
 
 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DMEGATINYCORE="{version}" -DMEGATINYCORE_MAJOR={versionnum.major}UL -DMEGATINYCORE_MINOR={versionnum.minor}UL -DMEGATINYCORE_PATCH={versionnum.patch}UL -DMEGATINYCORE_RELEASED={versionnum.released}
 
@@ -25,6 +25,14 @@ build.optiondefines=-DF_CPU={build.f_cpu} -DCLOCK_SOURCE={build.clocksource} -DT
 #########################
 # AVR compile variables #
 #########################
+
+# Optimization flags for debugging
+# -mrelax does not work with debugging since debug line information
+# is completely garbeled. Therefore include {build.mrelax} only under
+# release flags (or better not at all)
+compiler.optimization_flags=-Os -ggdb3 -DNDEBUG
+compiler.optimization_flags.release=-Os -ggdb3 -DNDEBUG
+compiler.optimization_flags.debug=-Og -ggdb3 -DDEBUG
 
 compiler.warning_flags=-Wall
 compiler.warning_flags.none=-Wall
@@ -35,12 +43,12 @@ compiler.warning_flags.all=-Wall -Wextra
 # Default "compiler.path" is correct, change only if you want to override the initial value
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
-compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects {build.mrelax} -Werror=implicit-function-declaration -Wundef
-compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start} {build.mrelax}
+compiler.c.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects  -Werror=implicit-function-declaration -Wundef
+compiler.c.elf.flags={compiler.warning_flags} {compiler.optimization_flags} -flto -fuse-linker-plugin -Wl,--gc-sections -Wl,--section-start={build.text_section_start}
 compiler.c.elf.cmd=avr-gcc
-compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
+compiler.S.flags=-c {compiler.optimization_flags} -x assembler-with-cpp -flto -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++17 -fpermissive -Wno-sized-deallocation -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto {build.mrelax}
+compiler.cpp.flags=-c {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++17 -fpermissive -Wno-sized-deallocation -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
@@ -240,3 +248,30 @@ tools.serialupdi.bootloader.pattern="{cmd}" -u "{runtime.platform.path}/tools/pr
 # bootloader being erased but no sketches working)
 
 tools.serialupdi.program.pattern={upload.prog_interlock}"{cmd}" -u "{runtime.platform.path}/tools/prog.py"  -t {protocol} {program.extra_params} -d {build.mcu}{upload.workaround} --fuses 0:{bootloader.WDTCFG} 2:{bootloader.OSCCFG} 6:{bootloader.SYSCFG1} 7:{bootloader.APPEND} 8:{bootloader.BOOTEND} "-f{build.path}/{build.project_name}.hex" -a write {program.verbose}
+
+# Debugger configuration (general options)
+# ----------------------------------------
+debug.executable={build.path}/{build.project_name}.elf
+debug.toolchain=gcc
+debug.toolchain.path={runtime.tools.avrocd-tools.path}
+
+debug.server=openocd
+debug.server.openocd.path={debug.toolchain.path}/pyavrocd
+#next doesn't matter, but should be specified so that cortex-debug is happy
+debug.server.openocd.script=nix
+debug.cortex-debug.custom.gdbPath={debug.toolchain.path}/avr-gdb
+debug.cortex-debug.custom.overrideGDBServerStartedRegex=Listening on port \d+ for gdb connection
+debug.cortex-debug.custom.objdumpPath={runtime.tools.avr-gcc.path}/bin/avr-objdump
+debug.cortex-debug.custom.serverArgs.0=-s
+debug.cortex-debug.custom.serverArgs.1=nop
+debug.cortex-debug.custom.serverArgs.2=--device
+debug.cortex-debug.custom.serverArgs.3={build.mcu}
+debug.cortex-debug.custom.serverArgs.4=--manage
+debug.cortex-debug.custom.serverArgs.5=all
+debug.cortex-debug.custom.serverArgs.6=--F_CPU
+debug.cortex-debug.custom.serverArgs.7={build.f_cpu}
+debug.cortex-debug.custom.serverArgs.8=--elf-file
+debug.cortex-debug.custom.serverArgs.9={debug.executable}
+
+debug.cortex-debug.custom.runToEntryPoint=main
+debug.svd_file={debug.toolchain.path}/pyavrocd-util/svd/{build.mcu}.svd

--- a/megaavr/programmers.txt
+++ b/megaavr/programmers.txt
@@ -76,23 +76,51 @@ medbg.program.protocol=xplainedmini_updi
 medbg.program.tool=avrdude
 medbg.program.extra_params=-Pusb
 
-atmelice_updi.name=Atmel-ICE
+atmelice_updi.name=Atmel-ICE (UPDI mode)
 atmelice_updi.communication=usb
 atmelice_updi.protocol=atmelice_updi
-atmelice_updi.program.protocol=jtagice3_updi
+atmelice_updi.program.protocol=atmelice_updi
 atmelice_updi.program.tool=avrdude
 atmelice_updi.program.extra_params=-Pusb
 
 pickit4_updi.name=PICkit4 (UPDI mode)
 pickit4_updi.communication=usb
 pickit4_updi.protocol=pickit4_updi
-pickit4_updi.program.protocol=jtagice3_updi
+pickit4_updi.program.protocol=pickit4_updi
 pickit4_updi.program.tool=avrdude
 pickit4_updi.program.extra_params=-Pusb
 
 snap_updi.name=MPLAB SNAP (UPDI mode)
 snap_updi.communication=usb
 snap_updi.protocol=snap_updi
-snap_updi.program.protocol=jtagice3_updi
+snap_updi.program.protocol=snap_updi
 snap_updi.program.tool=avrdude
 snap_updi.program.extra_params=-Pusb
+
+jtagice3_updi.name=JTAGICE3 (UPDI mode)
+jtagice3_updi.communication=usb
+jtagice3_updi.protocol=jtag3updi
+jtagice3_updi.program.protocol=jtag3updi
+jtagice3_updi.program.tool=avrdude
+jtagice3_updi.program.extra_params=
+
+pickit5_updi.name=PICkit5 (UPDI mode)
+pickit5_updi.communication=usb
+pickit5_updi.protocol=pickit5_updi
+pickit5_updi.program.protocol=pickit5_updi
+pickit5_updi.program.tool=avrdude
+pickit5_updi.program.extra_params=
+
+pickit_basic_updi.name=PICkit Basic (UPDI mode)
+pickit_basic_updi.communication=usb
+pickit_basic_updi.protocol=pickit_basic_updi
+pickit_basic_updi.program.protocol=pickit_basic_updi
+pickit_basic_updi.program.tool=avrdude
+pickit_basic_updi.program.extra_params=
+
+atmel_powerdebugger_updi.name=Power Debugger (UPDI mode)
+atmel_powerdebugger_updi.communication=usb
+atmel_powerdebugger_updi.protocol=powerdebugger_updi
+atmel_powerdebugger_updi.program.protocol=powerdebugger_updi
+atmel_powerdebugger_updi.program.tool=avrdude
+atmel_powerdebugger_updi.program.extra_params=


### PR DESCRIPTION
The necessary changes to enable debugging are relatively minimal:
- A few additions and changes in platform.txt 
- A few more programmers in programmers.txt
- And you need to include a new tool: [PyAvrOCD](https://pyavrocd.io). How that can be accomplished can be seen at the end of the package file https://github.com/felias-fogg/megaTinyCore/blob/gh-pages/package_SpenceKonde_megaTinyCore_index.json 

If you want to play around with it, check out the [quickstart start guide for CNANO boards](https://pyavrocd.io/quick_arduino/#quickstart-curiosity-nano).

The most intrusive change is to disable the `-mrelax` option, since this optimization plays havoc with debugging information: https://github.com/MCUdude/MegaCoreX/issues/216
If you really want to support this option, it may be better to enable it via platform.local.txt or by implementing my [pragma-mechanism](https://github.com/MCUdude/TinyCore/blob/main/pragma.md). 

I would have loved to disable LTO, because this removes debug information about class structures, and it removes information about variables being global. However, I will rather wait for a new GCC version to be used, which fixes these bugs.